### PR TITLE
Make secret include API key and service ID

### DIFF
--- a/spec/unit/Authentication/JsonWebTokenSpec.php
+++ b/spec/unit/Authentication/JsonWebTokenSpec.php
@@ -17,8 +17,8 @@ use Firebase\JWT\SignatureInvalidException;
 class JsonWebTokenSpec extends ObjectBehavior
 {
 
-    const SERVICE_ID    = 'XXX';
-    const API_KEY       = 'YYY';
+    const SERVICE_ID    = '00000000-0000-4000-a000-000000000000';
+    const API_KEY       = 'cccccccc-cccc-4ccc-9ccc-cccccccccccc';
 
 
     function let(){
@@ -38,14 +38,35 @@ class JsonWebTokenSpec extends ObjectBehavior
 
     }
 
+    function it_fails_with_an_invalid_service_id(){
+
+        $this->beConstructedWith( 'invalid-service-id', self::API_KEY );
+
+        $this->shouldThrow(
+            '\InvalidArgumentException'
+        )->duringInstantiation();
+
+    }
+
     function it_fails_with_an_invalid_api_key(){
 
         $this->beConstructedWith( self::SERVICE_ID, 'invalid-api-key' );
 
-        $this->createToken()->shouldBeInvalidJWSToken();
+        $this->shouldThrow(
+           '\InvalidArgumentException'
+        )->duringInstantiation();
 
     }
 
+    function it_fails_when_the_api_keys_do_not_match(){
+
+        // Create using a different API key. When checked, we use self::API_KEY, thus the token should be invalid.
+
+        $this->beConstructedWith( self::SERVICE_ID, 'f47ac10b-58cc-4372-a567-0e02b2c3d479' );
+
+        $this->createToken()->shouldBeInvalidJWSToken();
+
+    }
 
     public function getMatchers()
     {

--- a/spec/unit/ClientSpec.php
+++ b/spec/unit/ClientSpec.php
@@ -125,6 +125,73 @@ class ClientSpec extends ObjectBehavior
 
     }
 
+    function it_works_with_an_api_key_only( HttpClientInterface $httpClient, JWTAuthenticationInterface $authenticator ){
+
+        //---------------------------------
+        // Test Setup
+
+        $options = $this->getConstructorOptions( $httpClient, $authenticator );
+        unset( $options['authenticator'] );
+
+        $options += [
+            'apiKey' => 'key_name-1546058f-5a25-4334-85ae-e68f2a44bbaf-522ec739-ca63-3ec5-b082-08ce08ad65e2',
+        ];
+
+        //---------------------------------
+        // Perform action
+
+        /*
+         * The below will throw an exception if a valid authenticator was not created.
+         */
+
+        $this->beConstructedWith( $options );
+
+        $this->httpClient->sendRequest( Argument::type('Psr\Http\Message\RequestInterface') )->willReturn(
+            new Response(
+                200,
+                ['Content-type'  => 'application/json'],
+                json_encode([])
+            )
+        );
+
+        $this->listNotifications();
+
+    }
+
+    function it_works_with_a_new_api_key_and_service_id( HttpClientInterface $httpClient, JWTAuthenticationInterface $authenticator ){
+
+        //---------------------------------
+        // Test Setup
+
+        $options = $this->getConstructorOptions( $httpClient, $authenticator );
+        unset( $options['authenticator'] );
+
+        $options += [
+            'serviceId' => '1546058f-5a25-4334-85ae-e68f2a44bbaf',
+            'apiKey' => 'key_name-1546058f-5a25-4334-85ae-e68f2a44bbaf-522ec739-ca63-3ec5-b082-08ce08ad65e2',
+        ];
+
+        //---------------------------------
+        // Perform action
+
+        /*
+         * The below will throw an exception if a valid authenticator was not created.
+         */
+
+        $this->beConstructedWith( $options );
+
+        $this->httpClient->sendRequest( Argument::type('Psr\Http\Message\RequestInterface') )->willReturn(
+            new Response(
+                200,
+                ['Content-type'  => 'application/json'],
+                json_encode([])
+            )
+        );
+
+        $this->listNotifications();
+
+    }
+
     //----------------------------------------------------------------------------------------------------------
     // Lookups (GETs) with expected success
 

--- a/spec/unit/ClientSpec.php
+++ b/spec/unit/ClientSpec.php
@@ -101,7 +101,7 @@ class ClientSpec extends ObjectBehavior
 
         $options += [
             'serviceId' => '1546058f-5a25-4334-85ae-e68f2a44bbaf',
-            'apiKey'    => '522ec739-ca63-3ec5-b082-08ce08ad65e2',
+            'apiKey'    => '522ec739-ca63-4ec5-b082-08ce08ad65e2',
         ];
 
         //---------------------------------
@@ -134,7 +134,7 @@ class ClientSpec extends ObjectBehavior
         unset( $options['authenticator'] );
 
         $options += [
-            'apiKey' => 'key_name-1546058f-5a25-4334-85ae-e68f2a44bbaf-522ec739-ca63-3ec5-b082-08ce08ad65e2',
+            'apiKey' => 'key_name-1546058f-5a25-4334-85ae-e68f2a44bbaf-522ec739-ca63-4ec5-b082-08ce08ad65e2',
         ];
 
         //---------------------------------
@@ -168,7 +168,7 @@ class ClientSpec extends ObjectBehavior
 
         $options += [
             'serviceId' => '1546058f-5a25-4334-85ae-e68f2a44bbaf',
-            'apiKey' => 'key_name-1546058f-5a25-4334-85ae-e68f2a44bbaf-522ec739-ca63-3ec5-b082-08ce08ad65e2',
+            'apiKey' => 'key_name-1546058f-5a25-4334-85ae-e68f2a44bbaf-522ec739-ca63-4ec5-b082-08ce08ad65e2',
         ];
 
         //---------------------------------
@@ -189,6 +189,23 @@ class ClientSpec extends ObjectBehavior
         );
 
         $this->listNotifications();
+
+    }
+
+    function it_fails_with_an_invalid_api_key( HttpClientInterface $httpClient, JWTAuthenticationInterface $authenticator ){
+
+        $options = $this->getConstructorOptions( $httpClient, $authenticator );
+        unset( $options['authenticator'] );
+
+        $options += [
+            'apiKey' => 'key_name-1546058f-5a25-4334-85ae-e68f2a44bbaf-522ec739-ca63-cec5-b082-08ce08ad65e2',
+        ];
+
+        $this->beConstructedWith( $options );
+
+        $this->shouldThrow(
+            '\InvalidArgumentException'
+        )->duringInstantiation();
 
     }
 

--- a/src/Authentication/JsonWebToken.php
+++ b/src/Authentication/JsonWebToken.php
@@ -3,6 +3,8 @@ namespace Alphagov\Notifications\Authentication;
 
 use Firebase\JWT\JWT;
 
+use InvalidArgumentException;
+
 /**
  * Class for generating JSON Web Token compatible with GOV.UK Notify.
  *
@@ -32,8 +34,33 @@ class JsonWebToken implements JWTAuthenticationInterface {
      */
     public function __construct( $serviceId, $key ){
 
+        if( !$this->isValidUUIDv4( $serviceId ) ){
+            throw new InvalidArgumentException( 'Invalid serviceId passed: ' . var_export($serviceId, true) );
+        }
+
+        if( !$this->isValidUUIDv4( $key ) ){
+            throw new InvalidArgumentException( 'Invalid apiKey passed: ' . var_export($key, true) );
+        }
+
         $this->serviceId = $serviceId;
         $this->key = $key;
+
+    }
+
+    /**
+     * Checks the passed string is a valid Version 4 UUID.
+     *
+     * See: https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_.28random.29
+     *
+     * @param string $string
+     * @return bool TRUE iff a valid Version 4 UUID.
+     */
+    private function isValidUUIDv4( $string ){
+
+        return is_string($string) && 1 === preg_match(
+            '/[a-f0-9]{8}\-[a-f0-9]{4}\-4[a-f0-9]{3}\-(8|9|a|b)[a-f0-9]{3}\-[a-f0-9]{12}/i',
+            $string
+        );
 
     }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -128,11 +128,15 @@ class Client {
 
             $this->setAuthenticator( $config['authenticator'] );
 
-        } elseif( isset($config['serviceId']) && isset($config['apiKey']) ){
+        } elseif( isset($config['apiKey']) ){
+
+            if( !isset($config['serviceId']) ) {
+              $config['serviceId'] = substr($config['apiKey'], -74, 36);
+            }
 
             $this->setAuthenticator(new Authentication\JsonWebToken(
                 $config['serviceId'],
-                $config['apiKey']
+                substr($config['apiKey'], -36, 36)
             ));
 
         } else {

--- a/src/Client.php
+++ b/src/Client.php
@@ -131,7 +131,7 @@ class Client {
         } elseif( isset($config['apiKey']) ){
 
             if( !isset($config['serviceId']) ) {
-              $config['serviceId'] = substr($config['apiKey'], -74, 36);
+              $config['serviceId'] = substr($config['apiKey'], -73, 36);
             }
 
             $this->setAuthenticator(new Authentication\JsonWebToken(

--- a/src/Client.php
+++ b/src/Client.php
@@ -130,6 +130,7 @@ class Client {
 
         } elseif( isset($config['apiKey']) ){
 
+            // If we're missing the serviceId, assume it's contained within the apiKey string.
             if( !isset($config['serviceId']) ) {
               $config['serviceId'] = substr($config['apiKey'], -73, 36);
             }


### PR DESCRIPTION
In research we’ve seen people mix up the service ID and API key because they’re both 36 character UUIDs. We can’t get rid of the service ID because it’s used to look up the API key.

Instead, we should change API key to be one long string, which contains both the service ID, API key and (optionally) the name of the key. For example:

**API key**
```
casework_production-8b3aa916-ec82-434e-b0c5-d5d9b371d6a3-dcdc5083-2fee-4fba-8afd-51f3f4bcb7b0
```

This commit changes the client to make the `secret` argument optional. If it’s not passed, they we attempt to extract it from the second argument (service ID) instead.

If a new-style API key is passed with a service ID as well then we just strip out the parts of the key that aren’t the secret.