### PR TITLE
Upgrade to use API v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+## [1.0.0] - 2016-12-16
+### Changed
+* Using v2 of the notification-api.
+
+* Update to `$this->sendSms()`:
+    * Added `reference`: an optional identifier you generate if you don’t want to use Notify’s `id`. It can be used to identify a single notification or a batch of notifications.
+    * Updated method signature:
+
+ ```php
+public function sendSms( $phoneNumber, $templateId, array $personalisation = array(), $reference = '' )
+```
+     * Where `$personalisation` and `$reference` can be omitted.
+
+* Update to `$this->sendEmail()`:
+    * Added `reference`: an optional identifier you generate if you don’t want to use Notify’s `id`. It can be used to identify a single notification or a batch of notifications.
+    * Updated method signature:
+
+ ```php
+public function sendEmail( $emailAddress, $templateId, array $personalisation = array(), $reference = '' )
+```
+     * Where `personalisation` and `reference` can be omitted.
+* Updated `$this->listNotifications()`
+    * Notifications can now be filtered by `reference` and `older_than`, see the README for details.
+
+# Prior versions
+
+Changelog not recorded - please see pull requests on github.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ public function sendSms( $phoneNumber, $templateId, array $personalisation = arr
  ```php
 public function sendEmail( $emailAddress, $templateId, array $personalisation = array(), $reference = '' )
 ```
-     * Where `personalisation` and `reference` can be omitted.
+     * Where `$personalisation` and `$reference` can be omitted.
 * Updated `$this->listNotifications()`
     * Notifications can now be filtered by `reference` and `older_than`, see the README for details.
 

--- a/README.md
+++ b/README.md
@@ -280,6 +280,8 @@ If the request is successful, `response` will be an `array `:
 ```php
 [
     "id": "notify_id",
+    "body": "Hello Foo",
+    "subject": "null|email_subject",
     "reference": "client reference",
     "email_address": "email address",
     "phone_number": "phone number",

--- a/README.md
+++ b/README.md
@@ -31,53 +31,14 @@ $notifyClient = new \Alphagov\Notifications\Client([
 
 Generate an API key by logging in to [GOV.UK Notify](https://www.notifications.service.gov.uk) and going to the **API integration** page.
 
+## Send messages
 
-#### Sending an email
-
-The method signature is:
-```php
-sendEmail( $to, $template, array $personalisation = array() )
-```
-
-Where
-
-* **$to** A required _string_ holding the recipient's email address.
-* **$template** A required _string_ that identifies a valid template. Templates are created in the admin tools.
-* **$personalisation** An optional _array_ holding any personalisation placeholders required by the template.
-
-An example request would look like:
-
-```php
-try {
-
-    $response = $notifyClient->sendEmail( 'betty@exmple.com', 'df10a23e-2c0d-4ea5-87fb-82e520cbf93c', [
-        'name' => 'Betty Smith',
-        'dob'  => '12 July 1968'
-    ]);
-
-} catch (NotifyException $e){}
-```
-
-**$response** will be an _array_ containing the decoded JSON response from the Notify API. For details, see: https://www.notifications.service.gov.uk/documentation
-
-An instance (or sub-class) of ``Alphagov\Notifications\Exception\NotifyException`` will be throw if an error occurs.
-
-#### Sending an SMS
+### Text message
 
 The method signature is:
 ```php
-sendSms( $to, $template, array $personalisation = array() )
+sendSms( $phoneNumber, $templateId, array $personalisation = array(), $reference = '' )
 ```
-
-Where
-
-* **$to** A required _string_ holding the recipient's mobile number. The number must:
-	* be a UK mobile number
-	* start +44
-	* not have a leading zero
-	* not have any whitespace, punctuation etc.
-* **$template** A required _string_ that identifies a valid template. Templates are created in the admin tools.
-* **$personalisation** An optional _array_ holding any personalisation placeholders required by the template.
 
 An example request would look like:
 
@@ -92,20 +53,212 @@ try {
 } catch (NotifyException $e){}
 ```
 
-**$response** will be an _array_ containing the decoded JSON response from the Notify API. For details, see: https://www.notifications.service.gov.uk/documentation
+<details>
+<summary>
+Response
+</summary>
 
-An instance (or sub-class) of ``Alphagov\Notifications\Exception\NotifyException`` will be throw if an error occurs.
+If the request is successful, `response` will be an `array`:
 
-#### Looking up the details of a Notification
+```php
+[
+    "id": "bfb50d92-100d-4b8b-b559-14fa3b091cda",
+    "reference": None,
+    "content": [
+        "body": "Some words",
+        "from_number": "40604"
+    ],
+    "uri": "https://api.notifications.service.gov.uk/v2/notifications/ceb50d92-100d-4b8b-b559-14fa3b091cd",
+    "template": [
+        "id": "ceb50d92-100d-4b8b-b559-14fa3b091cda",
+       "version": 1,
+       "uri": "https://api.notifications.service.gov.uk/v2/templates/bfb50d92-100d-4b8b-b559-14fa3b091cda"
+    ]
+]
+```
+
+Otherwise the client will raise a ``Alphagov\Notifications\Exception\NotifyException``:
+<table>
+<thead>
+<tr>
+<th>`error["status_code"]`</th>
+<th>`error["message"]`</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<pre>429</pre>
+</td>
+<td>
+<pre>
+[{
+    "error": "TooManyRequestsError",
+    "message": "Exceeded send limits (50) for today"
+}]
+</pre>
+</td>
+</tr>
+<tr>
+<td>
+<pre>400</pre>
+</td>
+<td>
+<pre>
+[{
+    "error": "BadRequestError",
+    "message": "Can"t send to this recipient using a team-only API key"
+]}
+</pre>
+</td>
+</tr>
+<tr>
+<td>
+<pre>400</pre>
+</td>
+<td>
+<pre>
+[{
+    "error": "BadRequestError",
+    "message": "Can"t send to this recipient when service is in trial mode
+                - see https://www.notifications.service.gov.uk/trial-mode"
+}]
+</pre>
+</td>
+</tr>
+</tbody>
+</table>
+</details>
+
+### Email
+
+The method signature is:
+```php
+sendEmail( $emailAddress, $templateId, array $personalisation = array(), $reference = '' )
+```
+
+An example request would look like:
+
+```php
+try {
+
+    $response = $notifyClient->sendEmail( 'betty@exmple.com', 'df10a23e-2c0d-4ea5-87fb-82e520cbf93c', [
+        'name' => 'Betty Smith',
+        'dob'  => '12 July 1968'
+    ]);
+
+} catch (NotifyException $e){}
+```
+
+<details>
+<summary>
+Response
+</summary>
+
+If the request is successful, `response` will be an `array`:
+
+```php
+[
+    "id": "bfb50d92-100d-4b8b-b559-14fa3b091cda",
+    "reference": None,
+    "content": [
+        "subject": "Licence renewal",
+        "body": "Dear Bill, your licence is due for renewal on 3 January 2016.",
+        "from_email": "the_service@gov.uk"
+    ],
+    "uri": "https://api.notifications.service.gov.uk/v2/notifications/ceb50d92-100d-4b8b-b559-14fa3b091cd",
+    "template": [
+        "id": "ceb50d92-100d-4b8b-b559-14fa3b091cda",
+        "version": 1,
+        "uri": "https://api.notificaitons.service.gov.uk/service/your_service_id/templates/bfb50d92-100d-4b8b-b559-14fa3b091cda"
+    ]
+]
+```
+
+Otherwise the client will raise a ``Alphagov\Notifications\Exception\NotifyException``:
+<table>
+<thead>
+<tr>
+<th>`error["status_code"]`</th>
+<th>`error["message"]`</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<pre>429</pre>
+</td>
+<td>
+<pre>
+[{
+    "error": "TooManyRequestsError",
+    "message": "Exceeded send limits (50) for today"
+}]
+</pre>
+</td>
+</tr>
+<tr>
+<td>
+<pre>400</pre>
+</td>
+<td>
+<pre>
+[{
+    "error": "BadRequestError",
+    "message": "Can"t send to this recipient using a team-only API key"
+]}
+</pre>
+</td>
+</tr>
+<tr>
+<td>
+<pre>400</pre>
+</td>
+<td>
+<pre>
+[{
+    "error": "BadRequestError",
+    "message": "Can"t send to this recipient when service is in trial mode
+                - see https://www.notifications.service.gov.uk/trial-mode"
+}]
+</pre>
+</td>
+</tr>
+</tbody>
+</table>
+</details>
+
+
+### Arguments
+
+
+#### `templateId`
+
+Find by clicking **API info** for the template you want to send.
+
+#### `personalisation`
+
+If a template has placeholders you need to provide their values. For example:
+
+```php
+personalisation = [
+    'name' => 'Betty Smith',
+    'dob'  => '12 July 1968'
+]
+```
+
+Otherwise the parameter can be omitted.
+
+#### `reference`
+
+An optional identifier you generate if you don’t want to use Notify’s `id`. It can be used to identify a single  notification or a batch of notifications.
+
+## Get the status of one message
 
 The method signature is:
 ```php
 getNotification( $notificationId )
 ```
-
-Where
-
-* **$notificationId** A required _string_ holding the notifications's ID; which would have been returned in response to sending a message.
 
 An example request would look like:
 
@@ -117,47 +270,205 @@ try {
 } catch (NotifyException $e){}
 ```
 
-**$response** will be an _array_ containing the decoded JSON response from the Notify API. For details, see: https://www.notifications.service.gov.uk/documentation
+<details>
+<summary>
+Response
+</summary>
 
-Or if no notification was found for the passed ID, $response will be ``NULL``.
+If the request is successful, `response` will be an `array `:
 
-An instance (or sub-class) of ``Alphagov\Notifications\Exception\NotifyException`` will be throw if an error occurs.
+```php
+[
+    "id": "notify_id",
+    "reference": "client reference",
+    "email_address": "email address",
+    "phone_number": "phone number",
+    "line_1": "full name of a person or company",
+    "line_2": "123 The Street",
+    "line_3": "Some Area",
+    "line_4": "Some Town",
+    "line_5": "Some county",
+    "line_6": "Something else",
+    "postcode": "postcode",
+    "type": "sms|letter|email",
+    "status": "current status",
+    "template": [
+        "version": 1,
+        "id": 1,
+        "uri": "/template/{id}/{version}"
+     ],
+    "created_at": "created at",
+    "sent_at": "sent to provider at",
+]
+```
 
-#### Returning a list of Notifications
+Otherwise the client will raise a ``Alphagov\Notifications\Exception\NotifyException``:
+<table>
+<thead>
+<tr>
+<th>`error["status_code"]`</th>
+<th>`error["message"]`</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<pre>404</pre>
+</td>
+<td>
+<pre>
+[{
+    "error": "NoResultFound",
+    "message": "No result found"
+}]
+</pre>
+</td>
+</tr>
+<tr>
+<td>
+<pre>400</pre>
+</td>
+<td>
+<pre>
+[{
+    "error": "ValidationError",
+    "message": "id is not a valid UUID"
+}]
+</pre>
+</td>
+</tr>
+</tbody>
+</table>
+</details>
 
+## Get the status of all messages
 The method signature is:
 ```php
 listNotifications( array $filters = array() )
 ```
 
-Where
-
-* **$filters** An optional _array_ which applies filters to the request. A requires can use zero or more filters. Supported filtered:
-    * ``status``; with values:
-        * sending
-        * delivered
-        * failed
-    * ``template_type``; with values:
-        * email
-        * sms
-    * ``page``; takes an _int_ for pagination. Default is 1.
-
 An example request would look like:
 
 ```php
-try {
-
     $response = $notifyClient->listNotifications([
+        'older_than' => 'c32e9c89-a423-42d2-85b7-a21cd4486a2a',
+        'reference' => 'weekly-reminders',
         'status' => 'delivered',
         'template_type' => 'sms'
     ]);
-
-} catch (NotifyException $e){}
 ```
 
-**$response** will be an _array_ containing the decoded JSON response from the Notify API. For details, see: https://www.notifications.service.gov.uk/documentation
+<details>
+<summary>
+Response
+</summary>
 
-An instance (or sub-class) of ``Alphagov\Notifications\Exception\NotifyException`` will be throw if an error occurs.
+If the request is successful, `response` will be an `array`:
+
+```php
+[
+    "notifications":
+    [
+            "id": "notify_id",
+            "reference": "client reference",
+            "email_address": "email address",
+            "phone_number": "phone number",
+            "line_1": "full name of a person or company",
+            "line_2": "123 The Street",
+            "line_3": "Some Area",
+            "line_4": "Some Town",
+            "line_5": "Some county",
+            "line_6": "Something else",
+            "postcode": "postcode",
+            "type": "sms | letter | email",
+            "status": sending | delivered | permanent-failure | temporary-failure | technical-failure
+            "template": [
+            "version": 1,
+            "id": 1,
+            "uri": "/template/{id}/{version}"
+        ],
+        "created_at": "created at",
+        "sent_at": "sent to provider at",
+        ],
+        …
+  ],
+  "links": [
+     "current": "/notifications?template_type=sms&status=delivered",
+     "next": "/notifications?other_than=last_id_in_list&template_type=sms&status=delivered"
+  ]
+]
+```
+
+Otherwise the client will raise a ``Alphagov\Notifications\Exception\NotifyException``:
+<table>
+<thead>
+<tr>
+<th>`error["status_code"]`</th>
+<th>`error["message"]`</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<pre>400</pre>
+</td>
+<td>
+<pre>
+[{
+    'error': 'ValidationError',
+    'message': 'bad status is not one of [created, sending, delivered, pending, failed, technical-failure, temporary-failure, permanent-failure]'
+}]
+</pre>
+</td>
+</tr>
+<tr>
+<td>
+<pre>400</pre>
+</td>
+<td>
+<pre>
+[{
+    "error": "ValidationError",
+    "message": "Apple is not one of [sms, email, letter]"
+}]
+</pre>
+</td>
+</tr>
+</tbody>
+</table>
+</details>
+
+### Arguments
+
+#### `older_than`
+
+If omitted all messages are returned. Otherwise you can filter to retrieve all notifications older than the given notification `id`.
+
+#### `template_type`
+
+If omitted all messages are returned. Otherwise you can filter by:
+
+* `email`
+* `sms`
+* `letter`
+
+
+#### `status`
+
+If omitted all messages are returned. Otherwise you can filter by:
+
+* `sending` - the message is queued to be sent by the provider.
+* `delivered` - the message was successfully delivered.
+* `failed` - this will return all failure statuses `permanent-failure`, `temporary-failure` and `technical-failure`.
+* `permanent-failure` - the provider was unable to deliver message, email or phone number does not exist; remove this recipient from your list.
+* `temporary-failure` - the provider was unable to deliver message, email box was full or the phone was turned off; you can try to send the message again.
+* `technical-failure` - Notify had a technical failure; you can try to send the message again.
+
+#### `reference`
+
+
+This is the `reference` you gave at the time of sending the notification. This can be omitted to ignore the filter.
+
 
 ## Development
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "alphagov/notifications-php-client",
   "description": "PHP client for GOV.UK Notifications",
+  "version": "1.0.0",
   "minimum-stability": "stable",
   "license": "MIT",
   "type": "library",

--- a/spec/integration/ClientSpec.php
+++ b/spec/integration/ClientSpec.php
@@ -47,27 +47,34 @@ class ClientSpec extends ObjectBehavior
         ]);
 
         $response->shouldBeArray();
+        $response->shouldHaveKey( 'id' );
+        $response['id']->shouldBeString();
 
-        $response['data']->shouldBeArray();
+        $response->shouldHaveKey( 'reference' );
 
-        $response['data']->shouldHaveKey( 'notification' );
-        $response['data']->shouldHaveKey( 'body' );
-        $response['data']->shouldHaveKey( 'subject' );
-        $response['data']->shouldHaveKey( 'template_version' );
+        $response->shouldHaveKey( 'content' );
+        $response['content']->shouldBeArray();
+        $response['content']->shouldHaveKey( 'from_email' );
+        $response['content']['from_email']->shouldBeString();
+        $response['content']->shouldHaveKey( 'body' );
+        $response['content']['body']->shouldBeString();
+        $response['content']['body']->shouldBe("Hello Foo\n\nFunctional test help make our world a better place");
+        $response['content']->shouldHaveKey( 'subject' );
+        $response['content']['subject']->shouldBeString();
+        $response['content']['subject']->shouldBe("Functional Tests are good");
 
-        $response['data']['notification']->shouldBeArray();
-        $response['data']['notification']->shouldHaveKey( 'id' );
-        $response['data']['notification']['id']->shouldBeString();
+        $response->shouldHaveKey( 'template' );
+        $response['template']->shouldBeArray();
+        $response['template']->shouldHaveKey( 'id' );
+        $response['template']['id']->shouldBeString();
+        $response['template']->shouldHaveKey( 'version' );
+        $response['template']['version']->shouldBeInteger();
+        $response['template']->shouldHaveKey( 'uri' );
 
-        $response['data']['body']->shouldBeString();
-        $response['data']['body']->shouldBe("Hello Foo\n\nFunctional test help make our world a better place");
+        $response->shouldHaveKey( 'uri' );
+        $response['uri']->shouldBeString();
 
-        $response['data']['subject']->shouldBeString();
-        $response['data']['subject']->shouldBe("Functional Tests are good");
-
-        $response['data']['template_version']->shouldBeInteger();
-
-        self::$notificationId = $response['data']['notification']['id']->getWrappedObject();
+        self::$notificationId = $response['id']->getWrappedObject();
 
     }
 
@@ -82,34 +89,41 @@ class ClientSpec extends ObjectBehavior
 
       // Retrieve email notification by id and verify contents
       $response = $this->getNotification($notificationId);
+      $response->shouldBeArray();
+      $response->shouldHaveKey( 'id' );
+      $response['id']->shouldBeString();
 
-      $response->shouldHaveKey('data');
-      $response['data']->shouldBeArray();
+      $response->shouldHaveKey( 'reference' );
+      $response->shouldHaveKey( 'email_address' );
+      $response['email_address']->shouldBeString();
+      $response->shouldHaveKey( 'phone_number' );
+      $response->shouldHaveKey( 'line_1' );
+      $response->shouldHaveKey( 'line_2' );
+      $response->shouldHaveKey( 'line_3' );
+      $response->shouldHaveKey( 'line_4' );
+      $response->shouldHaveKey( 'line_5' );
+      $response->shouldHaveKey( 'line_6' );
+      $response->shouldHaveKey( 'postcode' );
+      $response->shouldHaveKey( 'type' );
+      $response['type']->shouldBeString();
+      $response['type']->shouldBe('email');
+      $response->shouldHaveKey( 'status' );
+      $response['status']->shouldBeString();
 
-      $response['data']->shouldHaveKey( 'notification' );
-      $response['data']['notification']->shouldBeArray();
+      $response->shouldHaveKey( 'template' );
+      $response['template']->shouldBeArray();
+      $response['template']->shouldHaveKey( 'id' );
+      $response['template']['id']->shouldBeString();
+      $response['template']->shouldHaveKey( 'version' );
+      $response['template']['version']->shouldBeInteger();
+      $response['template']->shouldHaveKey( 'uri' );
+      $response['template']['uri']->shouldBeString();
 
-      $response['data']['notification']->shouldHaveKey( 'id' );
-      $response['data']['notification']['id']->shouldBeString();
-      $response['data']['notification']['id']->shouldBeEqualTo($notificationId);
+      $response->shouldHaveKey( 'created_at' );
+      $response->shouldHaveKey( 'sent_at' );
+      $response->shouldHaveKey( 'completed_at' );
 
-      $response['data']['notification']->shouldHaveKey( 'body' );
-      $response['data']['notification']['body']->shouldBeString();
-      $response['data']['notification']['body']->shouldBeEqualTo("Hello Foo\n\nFunctional test help make our world a better place");
-
-      $response['data']['notification']->shouldHaveKey( 'status' );
-      $response['data']['notification']['status']->shouldBeString();
-
-      $response['data']['notification']->shouldHaveKey( 'notification_type' );
-      $response['data']['notification']['notification_type']->shouldBeString();
-      $response['data']['notification']['notification_type']->shouldBeEqualTo("email");
-
-      $response['data']['notification']->shouldHaveKey( 'subject' );
-      $response['data']['notification']['subject']->shouldBeString();
-      $response['data']['notification']['subject']->shouldBeEqualTo("Functional Tests are good");
-
-      $response['data']['notification']->shouldHaveKey( 'template_version' );
-      $response['data']['notification']['template_version']->shouldBeInteger();
+      self::$notificationId = $response['id']->getWrappedObject();
 
     }
 
@@ -120,24 +134,31 @@ class ClientSpec extends ObjectBehavior
         ]);
 
         $response->shouldBeArray();
+        $response->shouldHaveKey( 'id' );
+        $response['id']->shouldBeString();
 
-        $response['data']->shouldBeArray();
+        $response->shouldHaveKey( 'reference' );
 
-        $response['data']->shouldHaveKey( 'notification' );
-        $response['data']->shouldHaveKey( 'body' );
-        $response['data']->shouldNotHaveKey( 'subject' );
-        $response['data']->shouldHaveKey( 'template_version' );
+        $response->shouldHaveKey( 'content' );
+        $response['content']->shouldBeArray();
+        $response['content']->shouldHaveKey( 'from_number' );
+        $response['content']['from_number']->shouldBeString();
+        $response['content']->shouldHaveKey( 'body' );
+        $response['content']['body']->shouldBeString();
+        $response['content']['body']->shouldBe("Hello Foo\n\nFunctional Tests make our world a better place");
 
-        $response['data']['notification']->shouldBeArray();
-        $response['data']['notification']->shouldHaveKey( 'id' );
-        $response['data']['notification']['id']->shouldBeString();
+        $response->shouldHaveKey( 'template' );
+        $response['template']->shouldBeArray();
+        $response['template']->shouldHaveKey( 'id' );
+        $response['template']['id']->shouldBeString();
+        $response['template']->shouldHaveKey( 'version' );
+        $response['template']['version']->shouldBeInteger();
+        $response['template']->shouldHaveKey( 'uri' );
 
-        $response['data']['body']->shouldBeString();
-        $response['data']['body']->shouldBe("Hello Foo\n\nFunctional Tests make our world a better place");
+        $response->shouldHaveKey( 'uri' );
+        $response['uri']->shouldBeString();
 
-        $response['data']['template_version']->shouldBeInteger();
-
-        self::$notificationId = $response['data']['notification']['id']->getWrappedObject();
+        self::$notificationId = $response['id']->getWrappedObject();
 
     }
 
@@ -152,32 +173,39 @@ class ClientSpec extends ObjectBehavior
 
       // Retrieve sms notification by id and verify contents
       $response = $this->getNotification($notificationId);
+      $response->shouldBeArray();
+      $response->shouldHaveKey( 'id' );
+      $response['id']->shouldBeString();
 
-      $response->shouldHaveKey('data');
-      $response['data']->shouldBeArray();
+      $response->shouldHaveKey( 'reference' );
+      $response->shouldHaveKey( 'email_address' );
+      $response->shouldHaveKey( 'phone_number' );
+      $response['phone_number']->shouldBeString();
+      $response->shouldHaveKey( 'line_1' );
+      $response->shouldHaveKey( 'line_2' );
+      $response->shouldHaveKey( 'line_3' );
+      $response->shouldHaveKey( 'line_4' );
+      $response->shouldHaveKey( 'line_5' );
+      $response->shouldHaveKey( 'line_6' );
+      $response->shouldHaveKey( 'postcode' );
+      $response->shouldHaveKey( 'type' );
+      $response['type']->shouldBeString();
+      $response['type']->shouldBe('sms');
+      $response->shouldHaveKey( 'status' );
+      $response['status']->shouldBeString();
 
-      $response['data']->shouldHaveKey( 'notification' );
-      $response['data']['notification']->shouldBeArray();
+      $response->shouldHaveKey( 'template' );
+      $response['template']->shouldBeArray();
+      $response['template']->shouldHaveKey( 'id' );
+      $response['template']['id']->shouldBeString();
+      $response['template']->shouldHaveKey( 'version' );
+      $response['template']['version']->shouldBeInteger();
+      $response['template']->shouldHaveKey( 'uri' );
+      $response['template']['uri']->shouldBeString();
 
-      $response['data']['notification']->shouldHaveKey( 'id' );
-      $response['data']['notification']['id']->shouldBeString();
-      $response['data']['notification']['id']->shouldBeEqualTo($notificationId);
-
-      $response['data']['notification']->shouldHaveKey( 'body' );
-      $response['data']['notification']['body']->shouldBeString();
-      $response['data']['notification']['body']->shouldBeEqualTo("Hello Foo\n\nFunctional Tests make our world a better place");
-
-      $response['data']['notification']->shouldHaveKey( 'status' );
-      $response['data']['notification']['status']->shouldBeString();
-
-      $response['data']['notification']->shouldHaveKey( 'notification_type' );
-      $response['data']['notification']['notification_type']->shouldBeString();
-      $response['data']['notification']['notification_type']->shouldBeEqualTo("sms");
-
-      $response['data']['notification']->shouldNotHaveKey( 'subject' );
-
-      $response['data']['notification']->shouldHaveKey( 'template_version' );
-      $response['data']['notification']['template_version']->shouldBeInteger();
+      $response->shouldHaveKey( 'created_at' );
+      $response->shouldHaveKey( 'sent_at' );
+      $response->shouldHaveKey( 'completed_at' );
 
     }
 
@@ -187,14 +215,10 @@ class ClientSpec extends ObjectBehavior
       $response = $this->listNotifications();
 
       $response->shouldHaveKey('links');
-      $response->shouldHaveKey('page_size');
-      $response->shouldHaveKey('notifications');
-      $response->shouldHaveKey('total');
-
       $response['links']->shouldBeArray();
-      $response['page_size']->shouldBeInteger();
+
+      $response->shouldHaveKey('notifications');
       $response['notifications']->shouldBeArray();
-      $response['total']->shouldBeInteger();
 
       $notifications = $response['notifications'];
       $total_notifications_count = count($notifications->getWrappedObject());
@@ -204,32 +228,49 @@ class ClientSpec extends ObjectBehavior
           $notification = $notifications[$i];
 
           $notification->shouldBeArray();
-
-          $notification->shouldHaveKey( 'notification_type' );
-          $notification['notification_type']->shouldBeString();
-          $notification_type = $notification['notification_type']->getWrappedObject();
-
           $notification->shouldHaveKey( 'id' );
           $notification['id']->shouldBeString();
 
-          $notification->shouldHaveKey( 'body' );
-          $notification['body']->shouldBeString();
-
+          $notification->shouldHaveKey( 'reference' );
+          $notification->shouldHaveKey( 'email_address' );
+          $notification->shouldHaveKey( 'phone_number' );
+          $notification->shouldHaveKey( 'line_1' );
+          $notification->shouldHaveKey( 'line_2' );
+          $notification->shouldHaveKey( 'line_3' );
+          $notification->shouldHaveKey( 'line_4' );
+          $notification->shouldHaveKey( 'line_5' );
+          $notification->shouldHaveKey( 'line_6' );
+          $notification->shouldHaveKey( 'postcode' );
           $notification->shouldHaveKey( 'status' );
           $notification['status']->shouldBeString();
 
-          $notification->shouldHaveKey( 'template_version' );
-          $notification['template_version']->shouldBeInteger();
+          $notification->shouldHaveKey( 'template' );
+          $notification['template']->shouldBeArray();
+          $notification['template']->shouldHaveKey( 'id' );
+          $notification['template']['id']->shouldBeString();
+          $notification['template']->shouldHaveKey( 'version' );
+          $notification['template']['version']->shouldBeInteger();
+          $notification['template']->shouldHaveKey( 'uri' );
+          $notification['template']['uri']->shouldBeString();
+
+          $notification->shouldHaveKey( 'created_at' );
+          $notification->shouldHaveKey( 'sent_at' );
+          $notification->shouldHaveKey( 'completed_at' );
+
+          $notification->shouldBeArray();
+
+          $notification->shouldHaveKey( 'type' );
+          $notification['type']->shouldBeString();
+          $notification['type']->shouldBeString();
+          $notification_type = $notification['type']->getWrappedObject();
 
           if ( $notification_type == "sms" ) {
 
-            $notification->shouldNotHaveKey( 'subject' );
+            $notification['phone_number']->shouldBeString();
 
           } elseif ( $notification_type == "email") {
 
-            $notification->shouldHaveKey( 'subject' );
-            $notification['subject']->shouldBeString();
-            $notification['subject']->shouldBeEqualTo("Functional Tests are good");
+            $notification['email_address']->shouldBeString();
 
           }
       }

--- a/spec/integration/ClientSpec.php
+++ b/spec/integration/ClientSpec.php
@@ -93,6 +93,11 @@ class ClientSpec extends ObjectBehavior
       $response->shouldHaveKey( 'id' );
       $response['id']->shouldBeString();
 
+      $response->shouldHaveKey( 'body' );
+      $response['body']->shouldBeString();
+      $response['body']->shouldBe("Hello Foo\n\nFunctional test help make our world a better place");
+
+      $response->shouldHaveKey( 'subject' );
       $response->shouldHaveKey( 'reference' );
       $response->shouldHaveKey( 'email_address' );
       $response['email_address']->shouldBeString();
@@ -176,6 +181,11 @@ class ClientSpec extends ObjectBehavior
       $response->shouldBeArray();
       $response->shouldHaveKey( 'id' );
       $response['id']->shouldBeString();
+
+      $response->shouldHaveKey( 'body' );
+      $response['body']->shouldBeString();
+      $response['body']->shouldBe("Hello Foo\n\nFunctional Tests make our world a better place");
+      $response->shouldHaveKey( 'subject' );
 
       $response->shouldHaveKey( 'reference' );
       $response->shouldHaveKey( 'email_address' );

--- a/spec/unit/ClientSpec.php
+++ b/spec/unit/ClientSpec.php
@@ -296,7 +296,12 @@ class ClientSpec extends ObjectBehavior
         //---------------------------------
         // Test Setup
 
-        $filters = ['status'=>'delivered', 'page'=>'1', 'template_type'=> 'sms', 'reference'=> 'client-ref'];
+        $filters = [
+            'older_than'=>'uuid',
+            'template_type'=> 'sms',
+            'reference'=> 'client-ref',
+            'status'=>'delivered'
+        ];
 
         $this->httpClient->sendRequest( Argument::type('Psr\Http\Message\RequestInterface') )->willReturn(
             new Response(

--- a/spec/unit/ClientSpec.php
+++ b/spec/unit/ClientSpec.php
@@ -296,7 +296,7 @@ class ClientSpec extends ObjectBehavior
         //---------------------------------
         // Test Setup
 
-        $filters = ['status'=>'delivered', 'page'=>'1', 'template_type'=> 'sms'];
+        $filters = ['status'=>'delivered', 'page'=>'1', 'template_type'=> 'sms', 'reference'=> 'client-ref'];
 
         $this->httpClient->sendRequest( Argument::type('Psr\Http\Message\RequestInterface') )->willReturn(
             new Response(
@@ -392,8 +392,8 @@ class ClientSpec extends ObjectBehavior
         // Test Setup
 
         $payload = [
-            'to' => '+447834000000',
-            'template'=> 118,
+            'phone_number' => '+447834000000',
+            'template_id'=> 118,
             'personalisation' => [
                 'name'=>'Fred'
             ]
@@ -410,7 +410,7 @@ class ClientSpec extends ObjectBehavior
         //---------------------------------
         // Perform action
 
-        $this->sendSms( $payload['to'], $payload['template'], $payload['personalisation'] );
+        $this->sendSms( $payload['phone_number'], $payload['template_id'], $payload['personalisation'] );
 
         //---------------------------------
         // Check result
@@ -481,11 +481,12 @@ class ClientSpec extends ObjectBehavior
         // Test Setup
 
         $payload = [
-            'to' => 'text@example.com',
-            'template'=> 118,
+            'email_address' => 'text@example.com',
+            'template_id'=> 118,
             'personalisation' => [
                 'name'=>'Fred'
-            ]
+            ],
+            'reference'=>'client-ref'
         ];
 
         $this->httpClient->sendRequest( Argument::type('Psr\Http\Message\RequestInterface') )->willReturn(
@@ -499,7 +500,7 @@ class ClientSpec extends ObjectBehavior
         //---------------------------------
         // Perform action
 
-        $this->sendEmail( $payload['to'], $payload['template'], $payload['personalisation'] );
+        $this->sendEmail( $payload['email_address'], $payload['template_id'], $payload['personalisation'], $payload['reference'] );
 
         //---------------------------------
         // Check result

--- a/src/Client.php
+++ b/src/Client.php
@@ -213,9 +213,10 @@ class Client {
      * Returns a list of all notifications for the current Service ID.
      *
      * Filter supports:
+     *  - older_than
+     *  - reference
      *  - status
      *  - template_type
-     *  - page
      *
      * @param array $filters
      *
@@ -225,7 +226,7 @@ class Client {
 
         // Only allow the following filter keys.
         $filters = array_intersect_key( $filters, array_flip([
-            'page',
+            'older_than',
             'reference',
             'status',
             'template_type',

--- a/src/Client.php
+++ b/src/Client.php
@@ -25,7 +25,7 @@ class Client {
      * @const string Current version of this client.
      * This follows Semantic Versioning (http://semver.org/)
      */
-    const VERSION = '0.6.0';
+    const VERSION = '1.0.0';
 
     /**
      * @const string The API endpoint for Notify production.

--- a/src/Client.php
+++ b/src/Client.php
@@ -157,18 +157,18 @@ class Client {
     /**
      * Send an SMS message.
      *
-     * @param string    $phone_number
-     * @param string    $template
+     * @param string    $phoneNumber
+     * @param string    $templateId
      * @param array     $personalisation
      * @param string    $reference
      *
      * @return array
      */
-    public function sendSms( $phone_number, $template, array $personalisation = array(), $reference = '' ){
+    public function sendSms( $phoneNumber, $templateId, array $personalisation = array(), $reference = '' ){
 
         return $this->httpPost(
             self::PATH_NOTIFICATION_SEND_SMS,
-            $this->buildPayload( 'sms', $phone_number, $template, $personalisation, $reference )
+            $this->buildPayload( 'sms', $phoneNumber, $templateId, $personalisation, $reference )
         );
 
     }
@@ -176,18 +176,18 @@ class Client {
     /**
      * Send an Email message.
      *
-     * @param string    $email_address
-     * @param string    $template
+     * @param string    $emailAddress
+     * @param string    $templateId
      * @param array     $personalisation
      * @param string    $reference
      *
      * @return array
      */
-    public function sendEmail( $email_address, $template, array $personalisation = array(), $reference = '' ){
+    public function sendEmail( $emailAddress, $templateId, array $personalisation = array(), $reference = '' ){
 
         return $this->httpPost(
             self::PATH_NOTIFICATION_SEND_EMAIL,
-            $this->buildPayload( 'email', $email_address, $template, $personalisation, $reference )
+            $this->buildPayload( 'email', $emailAddress, $templateId, $personalisation, $reference )
         );
 
     }
@@ -247,17 +247,18 @@ class Client {
     /**
      * Generates the payload expected by the API.
      *
+     * @param string    $type
      * @param string    $to
-     * @param string    $template
+     * @param string    $templateId
      * @param array     $personalisation
      * @param string    $reference
      *
      * @return array
      */
-    private function buildPayload( $type, $to, $template, array $personalisation, $reference ){
+    private function buildPayload( $type, $to, $templateId, array $personalisation, $reference ){
 
         $payload = [
-            'template_id'=> $template
+            'template_id'=> $templateId
         ];
 
         if ( $type == 'sms' ) {


### PR DESCRIPTION
This updates the client to use v2 of the [notifications-api](https://github.com/alphagov/notifications-api). 

Several changes have been made to the v2 API, notably:

- You can now send notifications with an optional `$reference` parameter 
- You can now retrieve notifications with additional filters:  `reference` and `older_than`
- `array` responses are now more concise

Refer to README for details

This also updates the version to v1.0.0 and has been newly added to `package.json`