### PR TITLE
Update Client to allow an optional sms_sender_id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tests/local
 .DS_Store
 environment.sh
 docker.env
+.vscode/launch.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [1.3.0] - 2017-11-03
 ### Changed
 
-* Update to NotificationsAPIClient.send_sms_notification()
+* Update to `$this->sendSms()`
     * added `smsSenderId`: an optional sms_sender_id specified when adding SMS senders under service settings. If this is not provided, the SMS sender will be the service default SMS sender. `smsSenderId` can be omitted.
 
 ## [1.2.0] - 2017-10-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
+## [1.3.0] - 2017-11-03
+### Changed
+
+* Update to NotificationsAPIClient.send_sms_notification()
+    * added `smsSenderId`: an optional sms_sender_id specified when adding SMS senders under service settings. If this is not provided, the SMS sender will be the service default SMS sender. `smsSenderId` can be omitted.
+
 ## [1.2.0] - 2017-10-25
 ### Changed
 
 * Update to `$this->sendEmail()`
-    * added `email_reply_to_id`: an optional email_reply_to_id specified when adding Email reply to addresses under service settings, if this is not provided the reply to email will be the service default reply to email. `email_reply_to_id` can be omitted.
+    * added `emailReplyToId`: an optional email_reply_to_id specified when adding Email reply to addresses under service settings, if this is not provided the reply to email will be the service default reply to email. `emailReplyToId` can be omitted.
 
 ## [1.1.0] - 2017-05-10
 ### Changed

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Generate an API key by logging in to [GOV.UK Notify](https://www.notifications.s
 
 The method signature is:
 ```php
-sendSms( $phoneNumber, $templateId, array $personalisation = array(), $reference = '' )
+sendSms( $phoneNumber, $templateId, array $personalisation = array(), $reference = '', $smsSenderId = NULL )
 ```
 
 An example request would look like:
@@ -45,10 +45,15 @@ An example request would look like:
 ```php
 try {
 
-    $response = $notifyClient->sendSms( '+447777111222', 'df10a23e-2c6d-4ea5-87fb-82e520cbf93a', [
-        'name' => 'Betty Smith',
-        'dob'  => '12 July 1968'
-    ]);
+    $response = $notifyClient->sendSms( 
+        '+447777111222', 
+        'df10a23e-2c6d-4ea5-87fb-82e520cbf93a', [
+            'name' => 'Betty Smith',
+            'dob'  => '12 July 1968'
+        ],
+        'unique_ref123',
+        '862bfaaf-9f89-43dd-aafa-2868ce2926a9'
+    );
 
 } catch (NotifyException $e){}
 ```
@@ -149,11 +154,45 @@ Otherwise the client will raise a ``Alphagov\Notifications\Exception\NotifyExcep
 </table>
 </details>
 
+<details>
+<summary>
+Arguments
+</summary>
+
+#### `templateId`
+
+Find by clicking **API info** for the template you want to send.
+
+#### `personalisation`
+
+If a template has placeholders you need to provide their values. For example:
+
+```php
+personalisation = [
+    'name' => 'Betty Smith',
+    'dob'  => '12 July 1968'
+]
+```
+
+Otherwise the parameter can be omitted.
+
+#### `reference`
+
+An optional identifier you generate if you don’t want to use Notify’s `id`. It can be used to identify a single  notification or a batch of notifications.
+
+#### `smsSenderId`
+
+Optional. Specifies the identifier of the sms sender to set for the notification. The identifiers are found in your service Settings, when you 'Manage' your 'Text message sender'.
+
+If you omit this argument your default sms sender will be set for the notification.
+
+</details>
+
 ### Email
 
 The method signature is:
 ```php
-sendEmail( $emailAddress, $templateId, array $personalisation = array(), $reference = '' )
+sendEmail( $emailAddress, $templateId, array $personalisation = array(), $reference = '', $emailReplyToId = NULL )
 ```
 
 An example request would look like:
@@ -161,10 +200,15 @@ An example request would look like:
 ```php
 try {
 
-    $response = $notifyClient->sendEmail( 'betty@example.com', 'df10a23e-2c0d-4ea5-87fb-82e520cbf93c', [
-        'name' => 'Betty Smith',
-        'dob'  => '12 July 1968'
-    ]);
+    $response = $notifyClient->sendEmail( 
+        'betty@example.com', 
+        'df10a23e-2c0d-4ea5-87fb-82e520cbf93c', [
+            'name' => 'Betty Smith',
+            'dob'  => '12 July 1968'
+        ],
+        'unique_ref123',
+        '862bfaaf-9f89-43dd-aafa-2868ce2926a9'
+        );
 
 } catch (NotifyException $e){}
 ```
@@ -265,9 +309,10 @@ Otherwise the client will raise a ``Alphagov\Notifications\Exception\NotifyExcep
 </table>
 </details>
 
-
-### Arguments
-
+<details>
+<summary>
+Arguments
+</summary>
 
 #### `templateId`
 
@@ -295,6 +340,8 @@ An optional identifier you generate if you don’t want to use Notify’s `id`. 
 Optional. Specifies the identifier of the email reply-to address to set for the notification. The identifiers are found in your service Settings, when you 'Manage' your 'Email reply to addresses'.
 
 If you omit this argument your default email reply-to address will be set for the notification.
+
+</details>
 
 ## Get the status of one message
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "alphagov/notifications-php-client",
   "description": "PHP client for GOV.UK Notifications",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "minimum-stability": "stable",
   "license": "MIT",
   "type": "library",

--- a/environment_test.sh
+++ b/environment_test.sh
@@ -5,3 +5,4 @@ export SMS_TEMPLATE_ID=31046c06-418a-49bf-86de-706b68415b47
 export NOTIFY_API_URL=https://api.notify.works
 export API_KEY=this-is-a-made-up-name_f869e87b-2b5d-4563-95f0-d8fe5bbd815c_80fee54f-01e7-4b48-8ab8-d8eae04be70e
 export EMAIL_REPLY_TO_ID=db8d1a9d-41ef-43cd-a04a-ed7d95214d95
+export SMS_SENDER_ID=e3b08b0e-323d-480b-8a3e-f972a75954d0

--- a/environment_test.sh
+++ b/environment_test.sh
@@ -1,8 +1,0 @@
-export FUNCTIONAL_TEST_EMAIL=notify-tests-preview+client_funct_tests@digital.cabinet-office.gov.uk
-export FUNCTIONAL_TEST_NUMBER=+447467330204
-export EMAIL_TEMPLATE_ID=f0bb62f7-5ddb-4bf8-aac7-c1e6aefd1524
-export SMS_TEMPLATE_ID=31046c06-418a-49bf-86de-706b68415b47
-export NOTIFY_API_URL=https://api.notify.works
-export API_KEY=this-is-a-made-up-name_f869e87b-2b5d-4563-95f0-d8fe5bbd815c_80fee54f-01e7-4b48-8ab8-d8eae04be70e
-export EMAIL_REPLY_TO_ID=db8d1a9d-41ef-43cd-a04a-ed7d95214d95
-export SMS_SENDER_ID=e3b08b0e-323d-480b-8a3e-f972a75954d0

--- a/spec/integration/ClientSpec.php
+++ b/spec/integration/ClientSpec.php
@@ -490,4 +490,55 @@ class ClientSpec extends ObjectBehavior
       $response['subject']->shouldBeNull();
     }
 
+    function it_receives_the_expected_response_when_sending_an_sms_notification_with_invaild_smsSenderId(){
+      
+        $this->shouldThrow('Alphagov\Notifications\Exception\ApiException')->duringSendSms( 
+          getenv('FUNCTIONAL_TEST_EMAIL'), 
+          getenv('SMS_TEMPLATE_ID'), 
+          [ "name" => "Foo" ],
+          '',
+          'invlaid_uuid'
+        );
+      }
+
+      function it_receives_the_expected_response_when_sending_an_sms_notification_with_valid_seender_id(){
+        
+        $response = $this->sendSms( 
+          getenv('FUNCTIONAL_TEST_NUMBER'), 
+          getenv('SMS_TEMPLATE_ID'), [
+              "name" => "Foo"
+          ],
+          'ref123',
+          getenv('SMS_SENDER_ID')
+        );
+
+        $response->shouldBeArray();
+        $response->shouldHaveKey( 'id' );
+        $response['id']->shouldBeString();
+
+        $response->shouldHaveKey( 'reference' );
+
+        $response->shouldHaveKey( 'content' );
+        $response['content']->shouldBeArray();
+        $response['content']->shouldHaveKey( 'from_number' );
+        $response['content']['from_number']->shouldBeString();
+        $response['content']->shouldHaveKey( 'body' );
+        $response['content']['body']->shouldBeString();
+        $response['content']['body']->shouldBe("Hello Foo\n\nFunctional Tests make our world a better place");
+
+        $response->shouldHaveKey( 'template' );
+        $response['template']->shouldBeArray();
+        $response['template']->shouldHaveKey( 'id' );
+        $response['template']['id']->shouldBeString();
+        $response['template']->shouldHaveKey( 'version' );
+        $response['template']['version']->shouldBeInteger();
+        $response['template']->shouldHaveKey( 'uri' );
+
+        $response->shouldHaveKey( 'uri' );
+        $response['uri']->shouldBeString();
+
+        self::$notificationId = $response['id']->getWrappedObject();
+
+    }
+
 }

--- a/spec/unit/ClientSpec.php
+++ b/spec/unit/ClientSpec.php
@@ -481,6 +481,33 @@ class ClientSpec extends ObjectBehavior
 
     }
 
+    function it_receives_the_expected_response_when_sending_sms_with_sms_sender_id(){
+        
+        //---------------------------------
+        // Test Setup
+
+        $id = self::SAMPLE_ID;
+
+        $this->httpClient->sendRequest( Argument::type('Psr\Http\Message\RequestInterface') )->willReturn(
+            new Response(
+                201,
+                ['Content-type'  => 'application/json'],
+                json_encode(['notification_id' => $id])
+            )
+        );
+
+        //---------------------------------
+        // Perform action
+
+        $response = $this->sendSms( '+447834000000', 118, [ 'name'=>'Fred' ], 'ref123', '1234567' );
+
+        //---------------------------------
+        // Check result
+
+        $response->shouldHaveKeyWithValue('notification_id', $id);
+
+    }
+
     function it_generates_the_expected_request_when_sending_email(){
 
         //---------------------------------

--- a/src/Client.php
+++ b/src/Client.php
@@ -310,7 +310,6 @@ class Client {
      * @param string    $templateId
      * @param array     $personalisation
      * @param string    $reference
-     * @param string    $emailReplyToId
      *
      * @return array
      */
@@ -338,6 +337,18 @@ class Client {
 
     }
 
+    /**
+     * Generates the payload expected by the API for email adding the optional items.
+     * 
+     * @param string    $type
+     * @param string    $to
+     * @param string    $templateId
+     * @param array     $personalisation
+     * @param string    $reference
+     * @param string    $emailReplyToId
+     *
+     * @return array
+     */
     private function buildEmailPayload( $type, $to, $templateId, array $personalisation, $reference, $emailReplyToId = NULL ) {
         
         $payload = $this->buildPayload( $type, $to, $templateId, $personalisation, $reference );
@@ -350,6 +361,18 @@ class Client {
     
     }
 
+    /**
+     * Generates the payload expected by the API for sms adding the optional items.
+     * 
+     * @param string    $type
+     * @param string    $to
+     * @param string    $templateId
+     * @param array     $personalisation
+     * @param string    $reference
+     * @param string    $smsSenderId
+     *
+     * @return array
+     */
     private function buildSmsPayload( $type, $to, $templateId, array $personalisation, $reference, $smsSenderId = NULL ){
 
         $payload = $this->buildPayload( $type, $to, $templateId, $personalisation, $reference );

--- a/src/Client.php
+++ b/src/Client.php
@@ -25,7 +25,7 @@ class Client {
      * @const string Current version of this client.
      * This follows Semantic Versioning (http://semver.org/)
      */
-    const VERSION = '1.2.0';
+    const VERSION = '1.3.0';
 
     /**
      * @const string The API endpoint for Notify production.

--- a/src/Client.php
+++ b/src/Client.php
@@ -168,11 +168,11 @@ class Client {
      *
      * @return array
      */
-    public function sendSms( $phoneNumber, $templateId, array $personalisation = array(), $reference = '' ){
+    public function sendSms( $phoneNumber, $templateId, array $personalisation = array(), $reference = '', $smsSenderId = NULL ){
 
         return $this->httpPost(
             self::PATH_NOTIFICATION_SEND_SMS,
-            $this->buildPayload( 'sms', $phoneNumber, $templateId, $personalisation, $reference )
+            $this->buildSmsPayload( 'sms', $phoneNumber, $templateId, $personalisation, $reference, $smsSenderId)
         );
 
     }
@@ -191,7 +191,7 @@ class Client {
 
         return $this->httpPost(
             self::PATH_NOTIFICATION_SEND_EMAIL,
-            $this->buildPayload( 'email', $emailAddress, $templateId, $personalisation, $reference, $emailReplyToId )
+            $this->buildEmailPayload( 'email', $emailAddress, $templateId, $personalisation, $reference, $emailReplyToId )
         );
 
     }
@@ -314,7 +314,7 @@ class Client {
      *
      * @return array
      */
-    private function buildPayload( $type, $to, $templateId, array $personalisation, $reference, $emailReplyToId = NULL ){
+    private function buildPayload( $type, $to, $templateId, array $personalisation, $reference ){
 
         $payload = [
             'template_id'=> $templateId
@@ -334,8 +334,28 @@ class Client {
             $payload['reference'] = $reference;
         }
 
+        return $payload;
+
+    }
+
+    private function buildEmailPayload( $type, $to, $templateId, array $personalisation, $reference, $emailReplyToId = NULL ) {
+        
+        $payload = $this->buildPayload( $type, $to, $templateId, $personalisation, $reference );
+
         if ( isset($emailReplyToId) && $emailReplyToId != '' ) {
             $payload['email_reply_to_id'] = $emailReplyToId;
+        }
+
+        return $payload;
+    
+    }
+
+    private function buildSmsPayload( $type, $to, $templateId, array $personalisation, $reference, $smsSenderId = NULL ){
+
+        $payload = $this->buildPayload( $type, $to, $templateId, $personalisation, $reference );
+        
+        if ( isset($smsSenderId) && $smsSenderId != '' ) {
+            $payload['sms_sender_id'] = $smsSenderId;
         }
 
         return $payload;


### PR DESCRIPTION
When using the sendSms function, you can now choose to specify a
sender by passing in an smsSenderId. If this is not included, the sms notification will come from the default sender for the service.

- Updated change log to include the changes
- Updated the client and refactored the buildPayload section to work better with sendSms and the optional sender_id
- Added Unit tests to test the functionality
- Added Integration tests