### PR TITLE
Fix composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
   "name": "alphagov/notifications-php-client",
   "description": "PHP client for GOV.UK Notifications",
-  "version": "1.6.0",
   "minimum-stability": "stable",
   "license": "MIT",
   "type": "library",
@@ -18,8 +17,7 @@
     "php-http/httplug": "^1.0",
     "guzzlehttp/psr7" : "^1.2",
     "php-http/client-implementation": "^1.0",
-    "php-http/guzzle6-adapter": "^1.1",
-    "alphagov/notifications-php-client": "^1.1"
+    "php-http/guzzle6-adapter": "^1.1"
   },
   "require-dev": {
     "phpspec/phpspec": "^2.0",


### PR DESCRIPTION
* `version` should *not* be used with source control (see https://getcomposer.org/doc/02-libraries.md#library-versioning)
* we shouldn't be requiring an old version of ourselves. that's just silly