### PR TITLE
remove the jessie etc/apt/sources.list file

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,8 +6,6 @@ ARG NO_PROXY
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-COPY etc/apt/sources.list /etc/apt/sources.list
-
 RUN \
 	echo "Install base packages" \
 	&& ([ -z "$HTTP_PROXY" ] || echo "Acquire::http::Proxy \"${HTTP_PROXY}\";" > /etc/apt/apt.conf.d/99HttpProxy) \

--- a/docker/etc/apt/sources.list
+++ b/docker/etc/apt/sources.list
@@ -1,3 +1,0 @@
-deb http://deb.debian.org/debian jessie main
-deb http://deb.debian.org/debian jessie-updates main
-deb http://security.debian.org jessie/updates main


### PR DESCRIPTION
php5.6-cli docker runs from a debian stretch base image now, and
andras isn't really sure why he added this file in the first place
