### PR TITLE
Set postage when sending a precompiled letter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.9.0] - 2019-01-28
+### Changed
+
+* Added a way to set postage when sending precompiled letters:
+  * set (optional) `$postage` argument on `sendPrecompiledLetter`
+
 ## [1.8.0] - 2018-11-01
 ### Changed
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -487,7 +487,7 @@ This is an invitation-only feature. Contact the GOV.UK Notify team on the [suppo
 ```php
 $response = $notifyClient->sendPrecompiledLetter(
     $reference,
-    $file_contents,
+    $pdf_data,
     $postage,
 );
 ```
@@ -502,29 +502,29 @@ A unique identifier you create if necessary. This reference identifies a single 
 $reference = 'STRING';
 ```
 
+#### pdf_data (required)
+
+The precompiled letter must be a PDF file. The method sends the contents of the file to GOV.UK Notify.
+
+```php
+$pdf_data = file_get_contents("path/to/pdf_file");
+try {
+
+    $response = $notifyClient->sendPrecompiledLetter(
+        'unique_ref123',
+        $pdf_data,
+        'first',
+    );
+
+} catch (NotifyException $e){}
+```
+
 #### postage (optional)
 
 You can choose first or second class postage for your precompiled letter. Set the value to `first` for first class, or `second` for second class. If you do not pass in this argument, the postage will default to second class.
 
 ```php
 $postage = 'first';
-```
-
-#### pdf_file (required)
-
-The precompiled letter must be a PDF file. The method sends the contents of the file to GOV.UK Notify.
-
-```php
-$file_contents = file_get_contents("path/to/pdf_file");
-try {
-
-    $response = $notifyClient->sendPrecompiledLetter(
-        'unique_ref123',
-        $file_contents,
-        'first',
-    );
-
-} catch (NotifyException $e){}
 ```
 
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -138,7 +138,7 @@ You can leave out this argument if a template does not have any placeholder fiel
 A unique identifier you can create if necessary. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address. For example:
 
 ```php
-$reference = 'STRING',
+$reference = 'STRING';
 ```
 You can leave out this argument if you do not have a reference.
 
@@ -255,7 +255,7 @@ You can leave out this argument if a template does not have any placeholder fiel
 A unique identifier you can create if necessary. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address.
 
 ```php
-$reference = 'STRING',
+$reference = 'STRING';
 ```
 
 You can leave out this argument if you do not have a reference.
@@ -423,7 +423,7 @@ $personalisation =
 A unique identifier you can create if necessary. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address. For example:
 
 ```php
-$reference = 'STRING',
+$reference = 'STRING';
 ```
 
 #### personalisation (optional)
@@ -485,9 +485,10 @@ This is an invitation-only feature. Contact the GOV.UK Notify team on the [suppo
 ### Method
 
 ```php
-response = notifications_client.send_precompiled_letter_notification(
+$response = $notifyClient->sendPrecompiledLetter(
     $reference,
-    $pdf_file
+    $file_contents,
+    $postage,
 );
 ```
 
@@ -498,7 +499,15 @@ response = notifications_client.send_precompiled_letter_notification(
 A unique identifier you create if necessary. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address.
 
 ```php
-$reference = 'STRING',
+$reference = 'STRING';
+```
+
+#### postage (optional)
+
+You can choose first or second class postage for your precompiled letter. Set the value to `first` for first class, or `second` for second class. If you do not pass in this argument, the postage will default to second class.
+
+```php
+$postage = 'first';
 ```
 
 #### pdf_file (required)
@@ -509,13 +518,15 @@ The precompiled letter must be a PDF file. The method sends the contents of the 
 $file_contents = file_get_contents("path/to/pdf_file");
 try {
 
-    $response = $notifyClient->sendLetter(
+    $response = $notifyClient->sendPrecompiledLetter(
         'unique_ref123',
-        $file_contents
+        $file_contents,
+        'first',
     );
 
 } catch (NotifyException $e){}
 ```
+
 
 ### Response
 
@@ -524,7 +535,8 @@ If the request to the client is successful, the client returns an `array`:
 ```php
 [
   "id" => "740e5834-3a29-46b4-9a6f-16142fde533a",
-  "reference" => "unique_ref123"
+  "reference" => "unique_ref123",
+  "postage" => "first"
 ];
 ```
 
@@ -540,6 +552,7 @@ If the request is not successful, the client returns an `Alphagov\Notifications\
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Cannot send letters when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"`<br>`}]`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode).|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Service is not allowed to send precompiled letters"`<br>`}]`|Contact the GOV.UK Notify team.|
 |`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "reference is a required property"`<br>`}]`|Add a `reference` argument to the method call.|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "postage invalid. It must be either first or second."`<br>`}]`|Change the value of `postage` argument in the method call to either 'first' or 'second'|
 |`429`|`[{`<br>`"error": "RateLimitError",`<br>`"message": "Exceeded rate limit for key type live of 10 requests per 20 seconds"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information.|
 |`429`|`[{`<br>`"error": "TooManyRequestsError",`<br>`"message": "Exceeded send limits (LIMIT NUMBER) for today"`<br>`}]`|Refer to [service limits](#service-limits) for the limit number.|
 
@@ -632,6 +645,7 @@ If the request to the client is successful, the client returns an `array`:
     "line_5" => "Some county",
     "line_6" => "Something else",
     "postcode" => "postcode",
+    "postage" => "null|first|second",
     "type" => "sms|letter|email",
     "status" => "current status",
     "template" => [
@@ -714,7 +728,7 @@ You can leave out this argument to ignore this filter.
 A unique identifier you can create if necessary. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address.
 
 ```php
-$reference = 'STRING',
+$reference = 'STRING';
 ```
 
 You can leave out this argument to ignore this filter.
@@ -749,6 +763,7 @@ If the request to the client is successful, the client returns an `array`.
             "line_5" => "Some county",
             "line_6" => "Something else",
             "postcode" => "postcode",
+            "postage" => "null|first|second",
             "type" => "sms | letter | email",
             "status" => sending | delivered | permanent-failure | temporary-failure | technical-failure
             "template" => [

--- a/spec/integration/ClientSpec.php
+++ b/spec/integration/ClientSpec.php
@@ -624,13 +624,14 @@ class ClientSpec extends ObjectBehavior
     function it_receives_the_expected_response_when_sending_a_precompiled_letter_notification(){
 
       $reference = 'my_ref_1234';
+      $postage = 'first';
 
       //---------------------------------
       // Perform action
 
       $file_contents = file_get_contents( './spec/integration/one_page_pdf.pdf' );
 
-      $response = $this->sendPrecompiledLetter( $reference, $file_contents );
+      $response = $this->sendPrecompiledLetter( $reference, $file_contents, $postage);
 
       $response->shouldBeArray();
       $response->shouldHaveKey( 'id' );
@@ -638,6 +639,9 @@ class ClientSpec extends ObjectBehavior
 
       $response->shouldHaveKey( 'reference' );
       $response['reference']->shouldBe("my_ref_1234");
+
+      $response->shouldHaveKey( 'postage' );
+      $response['postage']->shouldBe("first");
     }
 
     function it_exposes_error_details() {

--- a/src/Client.php
+++ b/src/Client.php
@@ -25,7 +25,7 @@ class Client {
      * @const string Current version of this client.
      * This follows Semantic Versioning (http://semver.org/)
      */
-    const VERSION = '1.8.0';
+    const VERSION = '1.9.0';
 
     /**
      * @const string The API endpoint for Notify production.

--- a/src/Client.php
+++ b/src/Client.php
@@ -228,11 +228,15 @@ class Client {
      *
      * @return array
      */
-    public function sendPrecompiledLetter( $reference, $pdf_data ){
+    public function sendPrecompiledLetter( $reference, $pdf_data, $postage = NULL ){
         $payload = [
           'reference' => $reference,
           'content' => base64_encode($pdf_data)
         ];
+
+        if ($postage != NULL) {
+          $payload['postage'] = $postage;
+        }
 
         return $this->httpPost(
             self::PATH_NOTIFICATION_SEND_LETTER,


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
Enable users to set postage class when they are sending a precompiled letter

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [x] I’ve written integration tests for these changes
- [x] I’ve updated the documentation (in `DOCUMENTATION.md` and `CHANGELOG.md`)
- [x] I’ve bumped the version number (`const VERSION` in `src/Client.php`)
