### PR TITLE
Link to precompiled letter specification from docs

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -504,7 +504,7 @@ $reference = 'STRING';
 
 #### pdf_data (required)
 
-The precompiled letter must be a PDF file. The method sends the contents of the file to GOV.UK Notify.
+The precompiled letter must be a PDF file which meets [the GOV.UK Notify PDF letter specification](https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.3.pdf). The method sends the contents of the file to GOV.UK Notify.
 
 ```php
 $pdf_data = file_get_contents("path/to/pdf_file");
@@ -592,7 +592,7 @@ You can only get the status of messages that are 7 days old or newer.
 |:---|:---|
 |Pending virus check|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
 |Virus scan failed|GOV.UK Notify found a potential virus in the precompiled letter file.|
-|Validation failed|Content in the precompiled letter file is outside the printable area.|
+|Validation failed|Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify PDF letter specification](https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.3.pdf) for more information.|
 
 ## Get the status of one message
 


### PR DESCRIPTION
## What problem does the pull request solve?

This will make it less likely that people need to ask us to send them the specification manually.

File is deployed here: https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.3.pdf

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [x] I’ve updated the documentation (in `DOCUMENTATION.md` and `CHANGELOG.md`)
- [ ] I’ve bumped the version number (`const VERSION` in `src/Client.php`)
