### PR TITLE
Removed direct dependancy on php-http/httplug in favour of psr/http-c…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.0.0] - 2019-07-11
+### Changed
+* The Notify PHP Client now requires a minimum PHP version of 7.1.0
+* Replaced dependency `php-http/httplug` with `psr/http-client`
+
 ## [1.9.0] - 2019-01-28
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
     "php": ">=5.4",
     "firebase/php-jwt": "^3.0",
     "psr/http-message": "^1.0",
-    "php-http/httplug": "^1.0 || ^2.0",
     "guzzlehttp/psr7" : "^1.2",
-    "php-http/client-implementation": "^1.0"
+    "php-http/client-implementation": "^1.0",
+    "psr/http-client": "^1.0"
   },
   "require-dev": {
     "phpspec/phpspec": "^2.0",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,22 +1,9 @@
-FROM php:5.6-cli
+FROM php:7.1-cli
 
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY
 
 ENV DEBIAN_FRONTEND=noninteractive
-
-RUN \
-	echo "Install base packages" \
-	&& ([ -z "$HTTP_PROXY" ] || echo "Acquire::http::Proxy \"${HTTP_PROXY}\";" > /etc/apt/apt.conf.d/99HttpProxy) \
-	&& apt-get update \
-	&& apt-get install -y --no-install-recommends \
-		zlib1g-dev \
-		make \
-		libpcre3-dev \
-	&& docker-php-ext-install zip \
-	&& curl -x "$HTTP_PROXY" -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-	&& echo "Clean up" \
-	&& rm -rf /var/lib/apt/lists/* /tmp/*
 
 WORKDIR /var/project

--- a/spec/integration/ClientSpec.php
+++ b/spec/integration/ClientSpec.php
@@ -11,7 +11,6 @@ use Alphagov\Notifications\Exception\UnexpectedValueException;
 use Alphagov\Notifications\Exception\ApiException;
 
 use GuzzleHttp\Psr7\Uri;
-use Http\Client\HttpClient as HttpClientInterface;
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\RequestInterface;
 

--- a/spec/unit/ClientSpec.php
+++ b/spec/unit/ClientSpec.php
@@ -9,7 +9,7 @@ use Alphagov\Notifications\Client;
 use Alphagov\Notifications\Exception as NotifyException;
 
 use GuzzleHttp\Psr7\Uri;
-use Http\Client\HttpClient as HttpClientInterface;
+use Psr\Http\Client\ClientInterface as HttpClientInterface;
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\RequestInterface;
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,10 +1,10 @@
 <?php
 namespace Alphagov\Notifications;
 
-use GuzzleHttp\Psr7\Uri;                            // Concrete PSR-7 URL representation.
-use GuzzleHttp\Psr7\Request;                        // Concrete PSR-7 HTTP Request
-use Psr\Http\Message\ResponseInterface;             // PSR-7 HTTP Response Interface
-use Http\Client\HttpClient as HttpClientInterface;  // Interface for a PSR-7 compatible HTTP Client.
+use GuzzleHttp\Psr7\Uri;                                     // Concrete PSR-7 URL representation.
+use GuzzleHttp\Psr7\Request;                                 // Concrete PSR-7 HTTP Request
+use Psr\Http\Message\ResponseInterface;                      // PSR-7 HTTP Response Interface
+use Psr\Http\Client\ClientInterface as HttpClientInterface;  // Interface for a PSR-7 compatible HTTP Client.
 
 use Alphagov\Notifications\Authentication\JWTAuthenticationInterface;
 
@@ -25,7 +25,7 @@ class Client {
      * @const string Current version of this client.
      * This follows Semantic Versioning (http://semver.org/)
      */
-    const VERSION = '1.9.0';
+    const VERSION = '2.0.0';
 
     /**
      * @const string The API endpoint for Notify production.


### PR DESCRIPTION
…lient

## What problem does the pull request solve?
Removed the client's dependancy on the php-http/httplug package and allowed the Client class to use Psr\Http\Client\ClientInterface for HTTP clients instead of the deprecated Http\Client\HttpClient

## Checklist

- [x] I’ve used the pull request template
- [x] I’ve ~~written~~ updated unit tests for these changes
- [ ] I’ve updated the documentation (in `DOCUMENTATION.md` and `CHANGELOG.md`)
- [x] I’ve bumped the version number (`const VERSION` in `src/Client.php`) to 2.0.0
