### PR TITLE
update dependencies when running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ help:
 
 .PHONY: dependencies
 dependencies:  ## Install build dependencies
-	/usr/local/bin/composer install
+	/usr/local/bin/composer update
 
 .PHONY: build
 build: dependencies ## Build project


### PR DESCRIPTION
previously, would only reinstall - but if the dependencies had changed it wouldn't update the lock file