### PR TITLE
dependency cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.0.0] - 2019-10-01
+### Removed
+
+* Dropped support for PHP versions older than 7.1
+
 ## [1.9.0] - 2019-01-28
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 ## [2.0.0] - 2019-10-01
 ### Removed
 
-* Dropped support for PHP versions older than 7.1
+* Dropped official support for PHP versions older than 7.1.
+
+### Changed
+
+* Removed unused dependencies from `composer.json`
 
 ## [1.9.0] - 2019-01-28
 ### Changed

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -433,9 +433,9 @@ The following parameters in the letter recipient's address are optional:
 ```php
 $personalisation =
     [
-    'address_line_3' => '123 High Street', 	
-    'address_line_4' => 'Richmond upon Thames', 	
-    'address_line_5' => 'London', 		
+    'address_line_3' => '123 High Street',
+    'address_line_4' => 'Richmond upon Thames',
+    'address_line_5' => 'London',
     'address_line_6' => 'Middlesex',
     ];
 ```

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     {
       "name": "GOV UK Notify",
       "email": "notify@digital-cabinet-office.gov.uk"
-    },  
+    },
     {
       "name": "Neil Smith",
       "email": "neil@nsmith.net"
@@ -17,10 +17,7 @@
   "require": {
     "php": ">=5.4",
     "firebase/php-jwt": "^3.0",
-    "psr/http-message": "^1.0",
-    "php-http/httplug": "^1.0 || ^2.0",
-    "guzzlehttp/psr7" : "^1.2",
-    "php-http/client-implementation": "^1.0"
+    "guzzlehttp/psr7" : "^1.2"
   },
   "require-dev": {
     "phpspec/phpspec": "^2.0",
@@ -28,7 +25,7 @@
     "php-http/curl-client": "*",
     "php-http/mock-client": "*",
     "php-http/socket-client": "*",
-    "php-http/guzzle6-adapter": "^1.1"
+    "php-http/guzzle6-adapter": "*"
   },
   "suggest": {
     "ext-curl": "To send requests using cURL"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:5.6-cli
+FROM php:7.3-cli
 
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
@@ -10,13 +10,9 @@ RUN \
 	echo "Install base packages" \
 	&& ([ -z "$HTTP_PROXY" ] || echo "Acquire::http::Proxy \"${HTTP_PROXY}\";" > /etc/apt/apt.conf.d/99HttpProxy) \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends \
-		zlib1g-dev \
-		make \
-		libpcre3-dev \
-	&& docker-php-ext-install zip \
-	&& curl -x "$HTTP_PROXY" -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-	&& echo "Clean up" \
-	&& rm -rf /var/lib/apt/lists/* /tmp/*
+	&& apt-get install -y --no-install-recommends git zip unzip
+
+RUN curl -x "$HTTP_PROXY" --silent --show-error https://getcomposer.org/installer | php -- --install-dir /usr/local/bin --filename composer
+
 
 WORKDIR /var/project

--- a/spec/integration/ClientSpec.php
+++ b/spec/integration/ClientSpec.php
@@ -650,12 +650,12 @@ class ClientSpec extends ObjectBehavior
         // missing personalisation
         $response = $this->sendEmail( getenv('FUNCTIONAL_TEST_EMAIL'), getenv('EMAIL_TEMPLATE_ID'), [] );
       } catch (ApiException $e) {
-        assert('$e->getCode() == 400;');
-        assert('$e->getErrorMessage() == \'BadRequestError: "Missing personalisation: name"\';');
-        assert('$e->getErrors()[0][\'error\'] == \'BadRequestError\'');
+        assert($e->getCode() == 400);
+        assert($e->getErrorMessage() == 'BadRequestError: "Missing personalisation: name"');
+        assert($e->getErrors()[0]['error'] == 'BadRequestError');
         $caught = true;
       }
-      assert('$caught == true;');
+      assert($caught == true);
     }
 
     function it_receives_the_expected_response_when_looking_up_received_texts() {
@@ -674,7 +674,7 @@ class ClientSpec extends ObjectBehavior
 
       $received_texts_count = count($received_texts->getWrappedObject());
 
-      assert('$received_texts_count > 0;');
+      assert($received_texts_count > 0);
 
       for( $i = 0; $i < $received_texts_count; $i++ ) {
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -25,7 +25,7 @@ class Client {
      * @const string Current version of this client.
      * This follows Semantic Versioning (http://semver.org/)
      */
-    const VERSION = '1.9.0';
+    const VERSION = '2.0.0';
 
     /**
      * @const string The API endpoint for Notify production.


### PR DESCRIPTION
# remove unused dependencies

notably httplug, which we required, didn't actually use, and caused lots of headaches to do with sub-dependency version clashes.

# test against php 7.3

php 5.6 has been EOL for over two years now. Clean up the dockerfile, and fix the clientspec which previously used a deprecated assert style.


## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [x] I’ve updated the documentation (in `DOCUMENTATION.md` and `CHANGELOG.md`)
- [x] I’ve bumped the version number (`const VERSION` in `src/Client.php`)
