### PR TITLE
Concourse test pr 70

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [3.0.0] - 2020-02-25
+### Removed
+
+* Dropped support for ^1.0 releases of HTTPlug (phphttp/httplug)
+    * HTTP clients must now use the `Psr\Http\Client\ClientInterface` (found in 
+    ^2.0 releases of HTTPlug) rather than `Http\Client\HttpClient` interface 
+    (found in ^1.0 releases of HTTPlug).
+
 ## [2.1.2] - 2020-01-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ### Removed
 
 * Dropped support for ^1.0 releases of HTTPlug (phphttp/httplug)
-    * HTTP clients must now use the `Psr\Http\Client\ClientInterface` (found in 
+    * HTTP clients may now use the `Psr\Http\Client\ClientInterface` (found in 
     ^2.0 releases of HTTPlug) rather than `Http\Client\HttpClient` interface 
     (found in ^1.0 releases of HTTPlug).
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "php-http/message": "^1.1",
     "php-http/curl-client": "*",
     "php-http/mock-client": "*",
-    "php-http/socket-client": "*",
+    "php-http/socket-client": "2.0.0-beta1",
     "php-http/guzzle6-adapter": "*"
   },
   "suggest": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,10 +1,10 @@
 <?php
 namespace Alphagov\Notifications;
 
-use GuzzleHttp\Psr7\Uri;                            // Concrete PSR-7 URL representation.
-use GuzzleHttp\Psr7\Request;                        // Concrete PSR-7 HTTP Request
-use Psr\Http\Message\ResponseInterface;             // PSR-7 HTTP Response Interface
-use Http\Client\HttpClient as HttpClientInterface;  // Interface for a PSR-7 compatible HTTP Client.
+use GuzzleHttp\Psr7\Uri;                                    // Concrete PSR-7 URL representation.
+use GuzzleHttp\Psr7\Request;                                // Concrete PSR-7 HTTP Request
+use Psr\Http\Message\ResponseInterface;                     // PSR-7 HTTP Response Interface
+use Psr\Http\Client\ClientInterface as HttpClientInterface; // Interface for a PSR-7 compatible HTTP Client.
 
 use Alphagov\Notifications\Authentication\JWTAuthenticationInterface;
 
@@ -25,7 +25,7 @@ class Client {
      * @const string Current version of this client.
      * This follows Semantic Versioning (http://semver.org/)
      */
-    const VERSION = '2.1.2';
+    const VERSION = '3.0.0';
 
     /**
      * @const string The API endpoint for Notify production.


### PR DESCRIPTION
https://github.com/alphagov/notifications-php-client/pull/70 but opened by a team member to allow our CI to run tests. I've then made a few changes based on comments in the original PR and rebased.

I'm not massively sure how to test this. Unit and integration tests run fine and the original PR opener was happy with it and they have implemented it into their own code so I'm assuming it is all good.

---
This PR allows the use of the PSR standard interface \Psr\Http\Client\ClientInterface in the creation of the notify client. Previously a check was made on Clients passed during construction to check that they adhered to the php-http/httplug \Http\Client\HttpClient interface. Even though this interface is identical in signature to the PSR implementation.

Version 2 of php-http/httplug fixed this by removing the body of HttpClient, instead, having it extend ClientInterface. Due to there being no fixed dependency on version 1 most all applications will currently be using version 2 as an indirect dependency of the Notify client.

This means that anyone using php-http libraries will see no change in behaviour with 1 caveat.

If they are using php-http/socket-client they will be fixed to ^1.0 of httplug. The new 2.0.0-beta version of socket-client changes that to ^2.0. Hopefully it's out of beta soon.

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [x ] I’ve updated the documentation (in `DOCUMENTATION.md` and `CHANGELOG.md`)
- [x ] I’ve bumped the version number (`const VERSION` in `src/Client.php`)
