### PR TITLE
Bump to 3.0.1 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.0.1] - 2020-03-31
+### Removed
+
+* Bumped firebase/php-jwt from 3.0.0 to 5.0.0 to bring in latest bugfixes and features
+
 ## [3.0.0] - 2020-02-25
 ### Removed
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -25,7 +25,7 @@ class Client {
      * @const string Current version of this client.
      * This follows Semantic Versioning (http://semver.org/)
      */
-    const VERSION = '3.0.0';
+    const VERSION = '3.0.1';
 
     /**
      * @const string The API endpoint for Notify production.


### PR DESCRIPTION
I forgot to include this in https://github.com/alphagov/notifications-php-client/pull/80/files
so am including it here.

Wasn't sure if this was a major breaking change rather than a bug fix.
Technically no outward behaviour is difference which leads me to a patch
but also people can no longer use php-jwt version < 5.0.0 so could be
argued to be a major.

I've gone minor as for most people I'm sure this won't make any
difference in the slightest

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [x] I’ve updated the documentation (in `DOCUMENTATION.md` and `CHANGELOG.md`)
- [x] I’ve bumped the version number (`const VERSION` in `src/Client.php`)
