### PR TITLE
Update docs to catch ApiException rather than NotifyException

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -105,7 +105,7 @@ try {
         '862bfaaf-9f89-43dd-aafa-2868ce2926a9'
     );
 
-} catch (NotifyException $e){}
+} catch (ApiException $e){}
 ```
 
 ### Arguments
@@ -192,7 +192,7 @@ All messages sent using the [team and whitelist](#team-and-whitelist) or [live](
 
 ### Error codes
 
-If the request is not successful, the client returns an `Alphagov\Notifications\Exception\NotifyException` object containing the relevant error code.
+If the request is not successful, the client returns an `Alphagov\Notifications\Exception\ApiException` object containing the relevant error code.
 
 |exc->getCode()|exc->getErrors()|How to fix|
 |:---|:---|:---|
@@ -226,7 +226,7 @@ try {
         '862bfaaf-9f89-43dd-aafa-2868ce2926a9'
         );
 
-} catch (NotifyException $e){}
+} catch (ApiException $e){}
 ```
 
 
@@ -328,8 +328,9 @@ try {
             'link_to_file' => $notifyClient->prepareUpload( $file_data )
         ]
     );
-
-} catch (NotifyException $e){}
+}
+catch (ApiException $e){}
+catch (InvalidArgumentException $e){}
 ```
 
 ### Response
@@ -357,7 +358,7 @@ If the request to the client is successful, the client returns an `array`:
 
 ### Error codes
 
-If the request is not successful, the client returns an `Alphagov\Notifications\Exception\NotifyException` object containing the relevant error code.
+If the request is not successful, the client returns an `Alphagov\Notifications\Exception\ApiException` object containing the relevant error code.
 
 |exc->getCode()|exc->getErrors()|How to fix|
 |:---|:---|:---|
@@ -406,7 +407,7 @@ try {
         'unique_ref123'
     );
 
-} catch (NotifyException $e){}
+} catch (ApiException $e){}
 ```
 
 ### Arguments
@@ -486,7 +487,7 @@ If the request to the client is successful, the client returns an `array`:
 
 ### Error codes
 
-If the request is not successful, the client returns an `Alphagov\Notifications\Exception\NotifyException` object containing the relevant error code.
+If the request is not successful, the client returns an `Alphagov\Notifications\Exception\ApiException` object containing the relevant error code.
 
 |exc->getCode()|exc->getErrors()|How to fix|
 |:---|:---|:---|
@@ -537,7 +538,7 @@ try {
         'first',
     );
 
-} catch (NotifyException $e){}
+} catch (ApiException $e){}
 ```
 
 #### postage (optional)
@@ -563,7 +564,7 @@ If the request to the client is successful, the client returns an `array`:
 
 ### Error codes
 
-If the request is not successful, the client returns an `Alphagov\Notifications\Exception\NotifyException` object containing the relevant error code.
+If the request is not successful, the client returns an `Alphagov\Notifications\Exception\ApiException` object containing the relevant error code.
 
 |exc->getCode()|exc->getErrors()|How to fix|
 |:---|:---|:---|
@@ -630,7 +631,7 @@ try {
 
     $response = $notifyClient->getNotification( 'c32e9c89-a423-42d2-85b7-a21cd4486a2a' );
 
-} catch (NotifyException $e){}
+} catch (ApiException $e){}
 ```
 
 ### Arguments
@@ -675,7 +676,7 @@ If the request to the client is successful, the client returns an `array`:
 
 ### Error codes
 
-If the request is not successful, the client will return an `Alphagov\Notifications\Exception\NotifyException` object containing the relevant error code:
+If the request is not successful, the client will return an `Alphagov\Notifications\Exception\ApiException` object containing the relevant error code:
 
 |exc->getCode()|exc->getErrors()|How to fix|
 |:---|:---|:---|
@@ -805,7 +806,7 @@ If the request to the client is successful, the client returns an `array`.
 
 ### Error codes
 
-If the request is not successful, the client returns an `Alphagov\Notifications\Exception\NotifyException` object containing the relevant error code:
+If the request is not successful, the client returns an `Alphagov\Notifications\Exception\ApiException` object containing the relevant error code:
 
 |exc->getCode()|exc->getErrors()|How to fix|
 |:---|:---|:---|
@@ -842,7 +843,7 @@ If the request to the client is successful, the client will return a `string` co
 
 ### Error codes
 
-If the request is not successful, the client throws an `Alphagov\Notifications\Exception\NotifyException` object containing the relevant error code:
+If the request is not successful, the client throws an `Alphagov\Notifications\Exception\ApiException` object containing the relevant error code:
 
 |error.status_code|error.message|How to fix|
 |:---|:---|:---|
@@ -893,7 +894,7 @@ If the request to the client is successful, the client returns an `array`.
 
 ### Error codes
 
-If the request is not successful, the client returns an `Alphagov\Notifications\Exception\NotifyException` object containing the relevant error code:
+If the request is not successful, the client returns an `Alphagov\Notifications\Exception\ApiException` object containing the relevant error code:
 
 |exc->getCode()|exc->getErrors()|How to fix|
 |:---|:---|:---|
@@ -939,7 +940,7 @@ If the request to the client is successful, the client returns an `array`.
 
 ### Error codes
 
-If the request is not successful, the client returns an `Alphagov\Notifications\Exception\NotifyException` object containing the relevant error code:
+If the request is not successful, the client returns an `Alphagov\Notifications\Exception\ApiException` object containing the relevant error code:
 
 |exc->getCode()|exc->getErrors()|How to fix|
 |:---|:---|:---|
@@ -1048,7 +1049,7 @@ If the request to the client is successful, the client returns an `array`.
 
 ### Error codes
 
-If the request is not successful, the client returns an `Alphagov\Notifications\Exception\NotifyException` object containing the relevant error code:
+If the request is not successful, the client returns an `Alphagov\Notifications\Exception\ApiException` object containing the relevant error code:
 
 |exc->getCode()|exc->getErrors()|Notes|
 |:---|:---|:---|
@@ -1126,7 +1127,7 @@ If the request to the client is successful, the client returns an `array`.
 ```
 ### Error codes
 
-If the request is not successful, the client returns an `Alphagov\Notifications\Exception\NotifyException` object containing the relevant error code:
+If the request is not successful, the client returns an `Alphagov\Notifications\Exception\ApiException` object containing the relevant error code:
 
 |exc->getCode()|exc->getErrors()|Notes|
 |:---|:---|:---|


### PR DESCRIPTION
As pointed out in
https://github.com/alphagov/notifications-php-client/issues/25,
the `NotifyException` class does not have a `getErrors` or `getCode`
method. By our docs currently saying that users should be default catch
the `NotifyException` class, then if a `NotifyException` that is not an
`ApiException` is thrown and the user tries to call `getErrors` or
`getCode` then another exception will be thrown.

This raises two possible solutions to fix
1) Add `getErrors` and `getCode` methods to `NotifyException. This
doesn't seem that appropriate though as not all types of
NotifyExceptions do have `errors` or an http error `code`.
2) Suggest users catch `ApiException`s when making API calls. This will
mean that a user will reliably be able to access `getErrors` and
`getCode`. The downside to this is that if another type of
`NotifyException` is thrown, then it will not be caught. However, this
would be no worse than our current situation and will only be uncaught
for errors that we really aren't expecting that should ideally be
investigated.

In the end, I went for option 2 as this seemed the least worst and also
was fairly quick to implement.

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve updated the documentation (in `DOCUMENTATION.md` and `CHANGELOG.md`)
- [ ] I’ve bumped the version number (`const VERSION` in `src/Client.php`)
