### PR TITLE
Add `is_csv` param to fix bug with downloading csv files not as txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.1.0] - 2020-08-04
+### Added
+
+* Add support for an optional `is_csv` parameter in the `prepareUpload()` function. This fixes a bug when sending a CSV file by email. This ensures that the file is downloaded as a CSV rather than a TXT file.
+
 ## [3.0.1] - 2020-03-31
 ### Removed
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -333,6 +333,28 @@ catch (ApiException $e){}
 catch (InvalidArgumentException $e){}
 ```
 
+#### CSV Files
+
+Uploads for CSV files should use the `is_csv` parameter on the `prepareUpload()` helper method.  For example:
+
+```php
+try {
+    $file_data = file_get_contents('/path/to/my/file.csv');
+
+    $response = $notifyClient->sendEmail(
+        'betty@example.com',
+        'df10a23e-2c0d-4ea5-87fb-82e520cbf93c',
+        [
+            'name' => 'Betty Smith',
+            'dob'  => '12 July 1968',
+            'link_to_file' => $notifyClient->prepareUpload( $file_data, true )
+        ]
+    );
+}
+catch (ApiException $e){}
+catch (InvalidArgumentException $e){}
+```
+
 ### Response
 
 If the request to the client is successful, the client returns an `array`:

--- a/spec/unit/ClientSpec.php
+++ b/spec/unit/ClientSpec.php
@@ -721,7 +721,12 @@ class ClientSpec extends ObjectBehavior
 
 
     function it_generates_the_expected_request_when_preparing_file_for_upload(){
-        $this->prepareUpload('%PDF-1.5 testpdf')->shouldReturn( [ 'file' => 'JVBERi0xLjUgdGVzdHBkZg==' ] );
+        $this->prepareUpload('%PDF-1.5 testpdf')->shouldReturn( [ 'file' => 'JVBERi0xLjUgdGVzdHBkZg==', 'is_csv' => false ] );
+    }
+
+
+    function it_generates_the_expected_request_when_preparing_a_csv_file_for_upload(){
+        $this->prepareUpload('%PDF-1.5 testpdf', true)->shouldReturn( [ 'file' => 'JVBERi0xLjUgdGVzdHBkZg==', 'is_csv' => true ] );
     }
 
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -25,7 +25,7 @@ class Client {
      * @const string Current version of this client.
      * This follows Semantic Versioning (http://semver.org/)
      */
-    const VERSION = '3.0.1';
+    const VERSION = '3.1.0';
 
     /**
      * @const string The API endpoint for Notify production.
@@ -392,15 +392,17 @@ class Client {
      * Prepare a file before adding it to the $personalisation array for the sendEmail function
      *
      * @param string $file_contents
+     * @param bool $is_csv
      *
-     * @return string
+     * @return array
      */
-    public function prepareUpload( $file_contents ){
+    public function prepareUpload( $file_contents, $is_csv = false ){
         if ( strlen($file_contents) > ( 2 * 1024 * 1024 )) {
             throw new Exception\InvalidArgumentException( 'File is larger than 2MB.' );
         }
         return [
-            "file" => base64_encode($file_contents)
+            "file" => base64_encode($file_contents),
+            "is_csv" => $is_csv
         ];
     }
 


### PR DESCRIPTION
Is equivalent to https://github.com/alphagov/notifications-python-client/pull/165/files
and means that CSV files are downloaded as CSV files rather than .txt
files when using doc download

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve updated the documentation (in `DOCUMENTATION.md` and `CHANGELOG.md`)
- [x] I’ve bumped the version number (`const VERSION` in `src/Client.php`)
