### PR TITLE
Add documentation and tests for letter_contact_block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.2.0] - 2020-08-06
+### Added
+
+* Added `letter_contact_block` to the responses for `getTemplate`, `getTemplateVersion` and `listTemplates`.
+
 ## [3.1.0] - 2020-08-04
 ### Added
 
@@ -12,8 +17,8 @@
 ### Removed
 
 * Dropped support for ^1.0 releases of HTTPlug (phphttp/httplug)
-    * HTTP clients may now use the `Psr\Http\Client\ClientInterface` (found in 
-    ^2.0 releases of HTTPlug) rather than `Http\Client\HttpClient` interface 
+    * HTTP clients may now use the `Psr\Http\Client\ClientInterface` (found in
+    ^2.0 releases of HTTPlug) rather than `Http\Client\HttpClient` interface
     (found in ^1.0 releases of HTTPlug).
 
 ## [2.1.2] - 2020-01-27

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -906,7 +906,8 @@ If the request to the client is successful, the client returns an `array`.
     "version" => "version",
     "created_by" => "someone@example.com",
     "body" => "body",
-    "subject" => "null|email_subject"
+    "subject" => "null|email or letter subject",
+    "letter_contact_block" => "null|letter_contact_block"
 ];
 ```
 
@@ -952,7 +953,8 @@ If the request to the client is successful, the client returns an `array`.
     "version" => "version",
     "created_by" => "someone@example.com",
     "body" => "body",
-    "subject" => "null|email_subject"
+    "subject" => "null|email or letter subject",
+    "letter_contact_block" => "null|letter_contact_block"
 ];
 ```
 
@@ -974,7 +976,7 @@ If the request is not successful, the client returns an `Alphagov\Notifications\
 This returns the latest version of all templates.
 
 ```php
-    $this->getAllTemplates(
+    $this->listTemplates(
       $template_type  // optional
     );
 ```
@@ -1004,7 +1006,8 @@ If the request to the client is successful, the client returns an `array`.
             "version" => "version",
             "created_by" => "someone@example.com",
             "body" => "body",
-            "subject" => "null|email_subject"
+            "subject" => "null|email or letter subject",
+            "letter_contact_block" => "null|letter_contact_block"
         ],
         [
             ... another template

--- a/spec/integration/ClientSpec.php
+++ b/spec/integration/ClientSpec.php
@@ -365,7 +365,7 @@ class ClientSpec extends ObjectBehavior
     function it_receives_the_expected_response_when_looking_up_an_email_template() {
       $templateId = getenv('EMAIL_TEMPLATE_ID');
 
-      // Retrieve sms notification by id and verify contents
+      // Retrieve email notification by id and verify contents
       $response = $this->getTemplate( $templateId );
 
       //
@@ -387,6 +387,7 @@ class ClientSpec extends ObjectBehavior
       $response['body']->shouldBe( "Hello ((name))\r\n\r\nFunctional test help make our world a better place" );
       $response['subject']->shouldBeString();
       $response['subject']->shouldBe( 'Functional Tests are good' );
+      $response['letter_contact_block']->shouldBeNull();
     }
 
     function it_receives_the_expected_response_when_looking_up_an_sms_template() {
@@ -416,6 +417,39 @@ class ClientSpec extends ObjectBehavior
       $response['version']->shouldBeInteger();
       $response['body']->shouldBe( "Hello ((name))\r\n\r\nFunctional Tests make our world a better place" );
       $response['subject']->shouldBeNull();
+      $response['letter_contact_block']->shouldBeNull();
+    }
+
+    function it_receives_the_expected_response_when_looking_up_a_letter_template() {
+      $templateId = getenv('LETTER_TEMPLATE_ID');
+
+      // Retrieve letter notification by id and verify contents
+      $response = $this->getTemplate( $templateId );
+
+      //
+      $response->shouldBeArray();
+      $response->shouldHaveKey( 'id' );
+      $response->shouldHaveKey( 'type' );
+      $response->shouldHaveKey( 'created_at' );
+      $response->shouldHaveKey( 'updated_at' );
+      $response->shouldHaveKey( 'created_by' );
+      $response->shouldHaveKey( 'version' );
+      $response->shouldHaveKey( 'body' );
+      $response->shouldHaveKey( 'subject' );
+
+      $response['id']->shouldBeString();
+      $response['id']->shouldBe( $templateId );
+      $response['type']->shouldBeString();
+      $response['type']->shouldBe( 'letter' );
+      $response['name']->shouldBeString();
+      $response['name']->shouldBe( 'Client functional letter template' );
+      $response['created_by']->shouldBeString();
+      $response['version']->shouldBeInteger();
+      $response['body']->shouldBe( "Hello ((address_line_1))" );
+      $response['subject']->shouldBeString();
+      $response['subject']->shouldBe( 'Main heading' );
+      $response['letter_contact_block']->shouldBe( "Government Digital Service\n" .
+      "The White Chapel Building\n10 Whitechapel High Street\nLondon\nE1 8QS\nUnited Kingdom" );
     }
 
     function it_receives_the_expected_response_when_looking_up_a_template_version() {
@@ -435,6 +469,7 @@ class ClientSpec extends ObjectBehavior
       $response->shouldHaveKey( 'version' );
       $response->shouldHaveKey( 'body' );
       $response->shouldHaveKey( 'subject' );
+      $response->shouldHaveKey( 'letter_contact_block' );
 
       $response['id']->shouldBeString();
       $response['id']->shouldBe( $templateId );
@@ -449,11 +484,12 @@ class ClientSpec extends ObjectBehavior
       $response['version']->shouldBe( $version );
       $response['body']->shouldBe("Functional Tests make our world a better place");
       $response['subject']->shouldBeNull();
+      $response['letter_contact_block']->shouldBeNull();
     }
 
     function it_receives_the_expected_response_when_looking_up_all_templates() {
 
-      // Retrieve all notifications and verify each is correct (email & sms)
+      // Retrieve all templates and verify each is correct (email, sms & letter)
       $response = $this->listTemplates();
 
       $response->shouldHaveKey('templates');
@@ -476,6 +512,7 @@ class ClientSpec extends ObjectBehavior
           $template->shouldHaveKey( 'version' );
           $template->shouldHaveKey( 'body' );
           $template->shouldHaveKey( 'subject' );
+          $template->shouldHaveKey( 'letter_contact_block' );
 
           $template['id']->shouldBeString();
           $template['created_at']->shouldBeString();
@@ -488,10 +525,15 @@ class ClientSpec extends ObjectBehavior
 
           if ( $template_type == "sms" ) {
             $template['subject']->shouldBeNull();
+            $template['letter_contact_block']->shouldBeNull();
 
-          } elseif ( $template_type == "email" || $template_type == "letter" ) {
-
+          } elseif ( $template_type == "email") {
             $template['subject']->shouldBeString();
+            $template['letter_contact_block']->shouldBeNull();
+
+          } elseif ( $template_type == "letter") {
+            $template['subject']->shouldBeString();
+            $template['letter_contact_block']->shouldBeString();
 
           }
       }

--- a/src/Client.php
+++ b/src/Client.php
@@ -25,7 +25,7 @@ class Client {
      * @const string Current version of this client.
      * This follows Semantic Versioning (http://semver.org/)
      */
-    const VERSION = '3.1.0';
+    const VERSION = '3.2.0';
 
     /**
      * @const string The API endpoint for Notify production.


### PR DESCRIPTION
`letter_contact_block` now gets returned as part of the response from the `getTemplate`, `getTemplateVersion` and `listTemplates` methods. This adds documentation and integration tests for the extra field.

Also fixed a method name in the docs which was wrong.