### PR TITLE
Adjust heading levels in DOCUMENTATION.md

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2,11 +2,11 @@
 
 This documentation is for developers interested in using the GOV.UK Notify PHP client to send emails, text messages or letters.
 
-# Set up the client
+## Set up the client
 
 The Notify PHP Client is based on a [PSR-7 HTTP model](https://www.php-fig.org/psr/psr-7/) [external link]. To install it, you must select your preferred HTTP client. You can follow these instructions to use [Guzzle v6 and v5](http://docs.guzzlephp.org/en/stable/) and [cURL](http://php.net/manual/en/book.curl.php) [external links].
 
-## Guzzle v6
+### Guzzle v6
 
 1. Use [Composer](https://getcomposer.org/)  [external link] to install the GOV.UK Notify PHP client. Run the following in the command line:
 
@@ -27,7 +27,7 @@ The Notify PHP Client is based on a [PSR-7 HTTP model](https://www.php-fig.org/p
 
 To get an API key, [sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __API integration__ page. You can find more information in the [API keys](#api-keys) section of this documentation.
 
-## Guzzle v5
+### Guzzle v5
 
 1. Use [Composer](https://getcomposer.org/)  [external link] to install the GOV.UK Notify PHP client. Run the following in the command line:
 
@@ -53,7 +53,7 @@ To get an API key, [sign in to GOV.UK Notify](https://www.notifications.service.
 
 To get an API key, [sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __API integration__ page. You can find more information in the [API keys](#api-keys) section of this documentation.
 
-## cURL
+### cURL
 
 1. Use [Composer](https://getcomposer.org/)  [external link] to install the GOV.UK Notify PHP client. Run the following in the command line:
 
@@ -79,13 +79,13 @@ You can now use the [autoloader](https://getcomposer.org/doc/01-basic-usage.md#a
 
 To get an API key, [sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __API integration__ page. You can find more information in the [API keys](#api-keys) section of this documentation.
 
-# Send a message
+## Send a message
 
 You can use GOV.UK Notify to send text messages, emails and letters.
 
-## Send a text message
+### Send a text message
 
-### Method
+#### Method
 
 ```php
 sendSms( $phoneNumber, $templateId, array $personalisation = array(), $reference = '', $smsSenderId = NULL  )
@@ -108,13 +108,13 @@ try {
 } catch (ApiException $e){}
 ```
 
-### Arguments
+#### Arguments
 
-#### phoneNumber (required)
+##### phoneNumber (required)
 
 The phone number of the recipient of the text message. This can be a UK or international number.
 
-#### templateId (required)
+##### templateId (required)
 
 To find the template ID:
 
@@ -122,7 +122,7 @@ To find the template ID:
 1. Go to the __Templates__ page and select the relevant template.
 1. Select __Copy template ID to clipboard__.
 
-#### personalisation (optional)
+##### personalisation (optional)
 
 If a template has placeholder fields for personalised information such as name or application date, you must provide their values in a dictionary with key value pairs. For example:
 
@@ -135,7 +135,7 @@ $personalisation = [
 
 You can leave out this argument if a template does not have any placeholder fields for personalised information.
 
-#### reference (optional)
+##### reference (optional)
 
 A unique identifier you can create if necessary. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address. For example:
 
@@ -144,7 +144,7 @@ $reference = 'STRING';
 ```
 You can leave out this argument if you do not have a reference.
 
-#### smsSenderId (optional)
+##### smsSenderId (optional)
 
 A unique identifier of the sender of the text message notification.
 
@@ -165,7 +165,7 @@ $smsSenderId='8e222534-7f05-4972-86e3-17c5d9f894e2'
 
 You can leave out this argument if your service only has one text message sender, or if you want to use the default sender.
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns an `array`:
 
@@ -190,7 +190,7 @@ If you are using the [test API key](#test), all your messages will come back wit
 
 All messages sent using the [team and guest list](#team-and-guest-list) or [live](#live) keys will appear on your dashboard.
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns an `Alphagov\Notifications\Exception\ApiException` object containing the relevant error code.
 
@@ -204,9 +204,9 @@ If the request is not successful, the client returns an `Alphagov\Notifications\
 |`429`|`[{`<br>`"error": "TooManyRequestsError",`<br>`"message": "Exceeded send limits (LIMIT NUMBER) for today"`<br>`}]`|Refer to [service limits](#daily-limits) for the limit number.|
 |`500`|`[{`<br>`"error": "Exception",`<br>`"message": "Internal server error"`<br>`}]`|Notify was unable to process the request, resend your notification.|
 
-## Send an email
+### Send an email
 
-### Method
+#### Method
 
 ```php
 sendEmail( $emailAddress, $templateId, array $personalisation = array(), $reference = '', $emailReplyToId = NULL )
@@ -230,13 +230,13 @@ try {
 ```
 
 
-### Arguments
+#### Arguments
 
-#### emailAddress (required)
+##### emailAddress (required)
 
 The email address of the recipient.
 
-#### templateId (required)
+##### templateId (required)
 
 To find the template ID:
 
@@ -244,7 +244,7 @@ To find the template ID:
 1. Go to the __Templates__ page and select the relevant template.
 1. Select __Copy template ID to clipboard__.
 
-#### personalisation (optional)
+##### personalisation (optional)
 
 If a template has placeholder fields for personalised information such as name or reference number, you need to provide their values in a dictionary with key value pairs. For example:
 
@@ -257,7 +257,7 @@ $personalisation = [
 
 You can leave out this argument if a template does not have any placeholder fields for personalised information.
 
-#### reference (optional)
+##### reference (optional)
 
 A unique identifier you can create if necessary. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address.
 
@@ -267,7 +267,7 @@ $reference = 'STRING';
 
 You can leave out this argument if you do not have a reference.
 
-#### emailReplyToId (optional)
+##### emailReplyToId (optional)
 
 This is an email address specified by you to receive replies from your users. You must add at least one reply-to email address before your service can go live.
 
@@ -287,20 +287,20 @@ $emailReplyToId='8e222534-7f05-4972-86e3-17c5d9f894e2'
 
 You can leave out this argument if your service only has one email reply-to address, or you want to use the default email address.
 
-## Send a file by email
+### Send a file by email
 
 To send a file by email, add a placeholder to the template then upload a file. The placeholder will contain a secure link to download the file.
 
 The links are unique and unguessable. GOV.UK Notify cannot access or decrypt your file.
 
-### Add contact details to the file download page
+#### Add contact details to the file download page
 
 1. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in).
 1. Go to the __Settings__ page.
 1. In the __Email__ section, select __Manage__ on the __Send files by email__ row.
 1. Enter the contact details you want to use, and select __Save__.
 
-### Add a placeholder to the template
+#### Add a placeholder to the template
 
 1. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in).
 1. Go to the __Templates__ page and select the relevant email template.
@@ -309,7 +309,7 @@ The links are unique and unguessable. GOV.UK Notify cannot access or decrypt you
 
 "Download your file at: ((link_to_file))"
 
-### Upload your file
+#### Upload your file
 
 You can upload PDF, CSV, .odt, .txt and MS Word Document files. Your file must be smaller than 2MB.. [Contact the GOV.UK Notify team](https://www.notifications.service.gov.uk/support/ask-question-give-feedback) if you need to send other file types.
 
@@ -333,7 +333,7 @@ catch (ApiException $e){}
 catch (InvalidArgumentException $e){}
 ```
 
-#### CSV Files
+##### CSV Files
 
 Uploads for CSV files should use the `is_csv` parameter on the `prepareUpload()` helper method.  For example:
 
@@ -355,7 +355,7 @@ catch (ApiException $e){}
 catch (InvalidArgumentException $e){}
 ```
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns an `array`:
 
@@ -378,7 +378,7 @@ If the request to the client is successful, the client returns an `array`:
 ```
 
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns an `Alphagov\Notifications\Exception\ApiException` object containing the relevant error code.
 
@@ -396,9 +396,9 @@ If the request is not successful, the client returns an `Alphagov\Notifications\
 |`500`|`[{`<br>`"error": "Exception",`<br>`"message": "Internal server error"`<br>`}]`|Notify was unable to process the request, resend your notification.|
 |`N/A`|`Exception\InvalidArgumentException( 'File is larger than 2MB.' )`|The file is too big. Files must be smaller than 2MB.|
 
-## Send a letter
+### Send a letter
 
-### Prerequisites
+#### Prerequisites
 
 When you add a new service it will start in [trial mode](https://www.notifications.service.gov.uk/features/trial-mode). You can only send letters when your service is live.
 
@@ -408,7 +408,7 @@ To send Notify a request to go live:
 1. Go to the __Settings__ page.
 1. In the __Your service is in trial mode__ section, select __request to go live__.
 
-### Method
+#### Method
 
 ```php
 sendLetter( $templateId, array $personalisation = array(), $reference = '' )
@@ -432,9 +432,9 @@ try {
 } catch (ApiException $e){}
 ```
 
-### Arguments
+#### Arguments
 
-#### templateId (required)
+##### templateId (required)
 
 To find the template ID:
 
@@ -442,7 +442,7 @@ To find the template ID:
 1. Go to the __Templates__ page and select the relevant template.
 1. Select __Copy template ID to clipboard__.
 
-#### personalisation (required)
+##### personalisation (required)
 
 The personalisation argument always contains the following parameters for the letter recipient’s address:
 
@@ -477,7 +477,7 @@ $personalisation =
           ];
 ```
 
-#### reference (optional)
+##### reference (optional)
 
 A unique identifier you can create if necessary. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address. For example:
 
@@ -485,7 +485,7 @@ A unique identifier you can create if necessary. This reference identifies a sin
 $reference = 'STRING';
 ```
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns an `array`:
 
@@ -507,7 +507,7 @@ If the request to the client is successful, the client returns an `array`:
 ];
 ```
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns an `Alphagov\Notifications\Exception\ApiException` object containing the relevant error code.
 
@@ -525,9 +525,9 @@ If the request is not successful, the client returns an `Alphagov\Notifications\
 |`500`|`[{`<br>`"error": "Exception",`<br>`"message": "Internal server error"`<br>`}]`|Notify was unable to process the request, resend your notification.|
 
 
-## Send a precompiled letter
+### Send a precompiled letter
 
-### Method
+#### Method
 
 ```php
 $response = $notifyClient->sendPrecompiledLetter(
@@ -537,9 +537,9 @@ $response = $notifyClient->sendPrecompiledLetter(
 );
 ```
 
-### Arguments
+#### Arguments
 
-#### reference (required)
+##### reference (required)
 
 A unique identifier you create if necessary. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address.
 
@@ -547,7 +547,7 @@ A unique identifier you create if necessary. This reference identifies a single 
 $reference = 'STRING';
 ```
 
-#### pdf_data (required)
+##### pdf_data (required)
 
 The precompiled letter must be a PDF file which meets [the GOV.UK Notify PDF letter specification](https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.4.pdf). The method sends the contents of the file to GOV.UK Notify.
 
@@ -564,7 +564,7 @@ try {
 } catch (ApiException $e){}
 ```
 
-#### postage (optional)
+##### postage (optional)
 
 You can choose first or second class postage for your precompiled letter. Set the value to `first` for first class, or `second` for second class. If you do not pass in this argument, the postage will default to second class.
 
@@ -573,7 +573,7 @@ $postage = 'first';
 ```
 
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns an `array`:
 
@@ -585,7 +585,7 @@ If the request to the client is successful, the client returns an `array`:
 ];
 ```
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns an `Alphagov\Notifications\Exception\ApiException` object containing the relevant error code.
 
@@ -599,13 +599,13 @@ If the request is not successful, the client returns an `Alphagov\Notifications\
 |`429`|`[{`<br>`"error": "RateLimitError",`<br>`"message": "Exceeded rate limit for key type live of 10 requests per 20 seconds"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information.|
 |`429`|`[{`<br>`"error": "TooManyRequestsError",`<br>`"message": "Exceeded send limits (LIMIT NUMBER) for today"`<br>`}]`|Refer to [service limits](#daily-limits) for the limit number.|
 
-# Get message status
+## Get message status
 
 Message status depends on the type of message that you have sent.
 
 You can only get the status of messages that are 7 days old or newer.
 
-## Status - email
+### Status - email
 
 |Status|Information|
 |:---|:---|
@@ -614,7 +614,7 @@ You can only get the status of messages that are 7 days old or newer.
 |Delivered|The message was successfully delivered.|
 |Failed|This covers all failure statuses:<br>- `permanent-failure` - "The provider could not deliver the message because the email address was wrong. You should remove these email addresses from your database."<br>- `temporary-failure` - "The provider could not deliver the message. This can happen when the recipient’s inbox is full. You can try to send the message again."<br>- `technical-failure` - "Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again."|
 
-## Status - text message
+### Status - text message
 
 |Status|Information|
 |:---|:---|
@@ -625,7 +625,7 @@ You can only get the status of messages that are 7 days old or newer.
 |Delivered|The message was successfully delivered.|
 |Failed|This covers all failure statuses:<br>- `permanent-failure` - "The provider could not deliver the message. This can happen if the phone number was wrong or if the network operator rejects the message. If you’re sure that these phone numbers are correct, you should [contact GOV.UK Notify support](https://www.notifications.service.gov.uk/support). If not, you should remove them from your database. You’ll still be charged for text messages that cannot be delivered."<br>- `temporary-failure` - "The provider could not deliver the message. This can happen when the recipient’s phone is off, has no signal, or their text message inbox is full. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages."<br>- `technical-failure` - "Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again. You will not be charged for text messages that are affected by a technical failure."|
 
-## Status - letter
+### Status - letter
 
 |Status|information|
 |:---|:---|
@@ -633,7 +633,7 @@ You can only get the status of messages that are 7 days old or newer.
 |Accepted|GOV.UK Notify has sent the letter to the provider to be printed.|
 |Received|The provider has printed and dispatched the letter.|
 
-## Status - precompiled letter
+### Status - precompiled letter
 
 |Status|information|
 |:---|:---|
@@ -641,11 +641,11 @@ You can only get the status of messages that are 7 days old or newer.
 |Virus scan failed|GOV.UK Notify found a potential virus in the precompiled letter file.|
 |Validation failed|Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify PDF letter specification](https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.4.pdf) for more information.|
 
-## Get the status of one message
+### Get the status of one message
 
 You can only get the status of messages that are 7 days old or newer.
 
-### Method
+#### Method
 
 ```php
 getNotification( $notificationId )
@@ -661,16 +661,16 @@ try {
 } catch (ApiException $e){}
 ```
 
-### Arguments
+#### Arguments
 
-#### notificationId (required)
+##### notificationId (required)
 
 The ID of the notification. To find the notification ID, you can either:
 
 * check the response to the [original notification method call](#response)
 * [sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __API integration__ page
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns an `array`:
 
@@ -702,7 +702,7 @@ If the request to the client is successful, the client returns an `array`:
 ];
 ```
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client will return an `Alphagov\Notifications\Exception\ApiException` object containing the relevant error code:
 
@@ -714,13 +714,13 @@ If the request is not successful, the client will return an `Alphagov\Notificati
 |`404`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No result found"`<br>`}]`|Check the notification ID.|
 
 
-## Get the status of multiple messages
+### Get the status of multiple messages
 
 This API call returns one page of up to 250 messages and statuses. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the `older_than` argument.
 
 You can only get the status of messages that are 7 days old or newer.
 
-### Method
+#### Method
 
 ```php
 listNotifications( array $filters = array() )
@@ -739,11 +739,11 @@ You can leave out the `older_than` argument to get the 250 most recent messages.
 
 To get older messages, pass the ID of an older notification into the `older_than` argument. This returns the next 250 oldest messages from the specified notification ID.
 
-### Arguments
+#### Arguments
 
 You can leave out any of these arguments to ignore these filters.
 
-#### template_type (optional)
+##### template_type (optional)
 
 You can filter by:
 
@@ -753,7 +753,7 @@ You can filter by:
 
 You can leave out this argument to ignore this filter.
 
-#### status (optional)
+##### status (optional)
 
 You can filter by each:
 
@@ -764,7 +764,7 @@ You can filter by each:
 
 You can leave out this argument to ignore this filter.
 
-#### reference (optional)
+##### reference (optional)
 
 A unique identifier you can create if necessary. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address.
 
@@ -774,7 +774,7 @@ $reference = 'STRING';
 
 You can leave out this argument to ignore this filter.
 
-#### older_than (optional)
+##### older_than (optional)
 
 Input the ID of a notification into this argument. If you use this argument, the method returns the next 250 received notifications older than the specified ID.
 
@@ -786,7 +786,7 @@ If you leave out this argument, the method returns the most recent 250 notificat
 
 The client only returns notifications that are 7 days old or newer. If the notification specified in this argument is older than 7 days, the client returns an empty response.
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns an `array`.
 
@@ -824,7 +824,7 @@ If the request to the client is successful, the client returns an `array`.
 ];
 ```
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns an `Alphagov\Notifications\Exception\ApiException` object containing the relevant error code:
 
@@ -837,9 +837,9 @@ If the request is not successful, the client returns an `Alphagov\Notifications\
 
 
 
-## Get a PDF for a letter notification
+### Get a PDF for a letter notification
 
-### Method
+#### Method
 
 This returns the PDF contents of a letter notification.
 
@@ -849,20 +849,20 @@ $pdf_file = $notifyClient->getPdfForLetter(
 )
 ```
 
-### Arguments
+#### Arguments
 
-#### notificationId (required)
+##### notificationId (required)
 
 The ID of the notification. To find the notification ID, you can either:
 
 * check the response to the [original notification method call](#get-the-status-of-one-message-response)
 * [sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __API integration__ page
 
-### Response
+#### Response
 
 If the request to the client is successful, the client will return a `string` containing the raw PDF data.
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client throws an `Alphagov\Notifications\Exception\ApiException` object containing the relevant error code:
 
@@ -878,11 +878,11 @@ If the request is not successful, the client throws an `Alphagov\Notifications\E
 |`404`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No result found"`<br>`}]`|Check the notification ID|
 
 
-# Get a template
+## Get a template
 
-## Get a template by ID
+### Get a template by ID
 
-### Method
+#### Method
 
 This returns the latest version of the template.
 
@@ -890,13 +890,13 @@ This returns the latest version of the template.
 $response = $notifyClient->getTemplate( 'templateId' );
 ```
 
-### Arguments
+#### Arguments
 
-#### templateId (required)
+##### templateId (required)
 
 The ID of the template. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __Templates__ page to find it.
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns an `array`.
 
@@ -914,7 +914,7 @@ If the request to the client is successful, the client returns an `array`.
 ];
 ```
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns an `Alphagov\Notifications\Exception\ApiException` object containing the relevant error code:
 
@@ -925,25 +925,25 @@ If the request is not successful, the client returns an `Alphagov\Notifications\
 |`404`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No Result Found"`<br>`}]`|Check your [template ID](#get-a-template-by-id-arguments-templateid-required).|
 
 
-## Get a template by ID and version
+### Get a template by ID and version
 
-### Method
+#### Method
 
 ```php
 $response = $notifyClient->getTemplateVersion( 'templateId', 1 );
 ```
 
-### Arguments
+#### Arguments
 
-#### templateId (required)
+##### templateId (required)
 
 The ID of the template. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __Templates__ page to find it.
 
-#### version (required)
+##### version (required)
 
 The version number of the template.
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns an `array`.
 
@@ -961,7 +961,7 @@ If the request to the client is successful, the client returns an `array`.
 ];
 ```
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns an `Alphagov\Notifications\Exception\ApiException` object containing the relevant error code:
 
@@ -972,9 +972,9 @@ If the request is not successful, the client returns an `Alphagov\Notifications\
 |`404`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No Result Found"`<br>`}]`|Check your [template ID](#get-a-template-by-id-and-version-arguments-templateid-required) and [version](#version-required).|
 
 
-## Get all templates
+### Get all templates
 
-### Method
+#### Method
 
 This returns the latest version of all templates.
 
@@ -984,9 +984,9 @@ This returns the latest version of all templates.
     );
 ```
 
-### Arguments
+#### Arguments
 
-#### template_type (optional)
+##### template_type (optional)
 
 If omitted, the method returns all templates. Otherwise you can filter by:
 
@@ -994,7 +994,7 @@ If omitted, the method returns all templates. Otherwise you can filter by:
 - `sms`
 - `letter`
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns an `array`.
 
@@ -1027,9 +1027,9 @@ If no templates exist for a template type or there no templates for a service, t
 ];
 ```
 
-## Generate a preview template
+### Generate a preview template
 
-### Method
+#### Method
 
 This generates a preview version of a template.
 
@@ -1040,13 +1040,13 @@ This generates a preview version of a template.
 
 The parameters in the personalisation argument must match the placeholder fields in the actual template. The API notification client will ignore any extra fields in the method.
 
-### Arguments
+#### Arguments
 
-#### templateId (required)
+##### templateId (required)
 
 The ID of the template. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __Templates__ page to find it.
 
-#### personalisation (required)
+##### personalisation (required)
 
 If a template has placeholder fields for personalised information such as name or reference number, you need to provide their values in a dictionary with key value pairs. For example:
 
@@ -1057,7 +1057,7 @@ $personalisation = [
 ];
 ```
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns an `array`.
 
@@ -1071,7 +1071,7 @@ If the request to the client is successful, the client returns an `array`.
 ];
 ```
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns an `Alphagov\Notifications\Exception\ApiException` object containing the relevant error code:
 
@@ -1083,7 +1083,7 @@ If the request is not successful, the client returns an `Alphagov\Notifications\
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: API key not found"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information.|
 
 
-# Get received text messages
+## Get received text messages
 
 This API call returns one page of up to 250 received text messages. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the `older_than` argument.
 
@@ -1091,13 +1091,13 @@ You can only get the status of messages that are 7 days old or newer.
 
 You can also set up [callbacks](#callbacks) for received text messages.
 
-## Enable received text messages
+### Enable received text messages
 
 Contact the GOV.UK Notify team using the [support page](https://www.notifications.service.gov.uk/support) or [chat to us on Slack](https://ukgovernmentdigital.slack.com/messages/C0E1ADVPC) to request a unique number for text message replies.
 
-## Get a page of received text messages
+### Get a page of received text messages
 
-### Method
+#### Method
 
 ```php
     $this->listReceivedTexts(
@@ -1109,9 +1109,9 @@ To get older messages, pass the ID of an older notification into the `older_than
 
 If you leave out the `older_than` argument, the client returns the most recent 250 notifications.
 
-### Arguments
+#### Arguments
 
-#### older_than (optional)
+##### older_than (optional)
 
 Input the ID of a received text message into this argument. If you use this argument, the client returns the next 250 received text messages older than the given ID. For example:
 
@@ -1123,7 +1123,7 @@ If you leave out the `older_than` argument, the client returns the most recent 2
 
 The client only returns notifications that are 7 days old or newer. If the notification specified in this argument is older than 7 days, the client returns an empty collection response.
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns an `array`.
 
@@ -1149,7 +1149,7 @@ If the request to the client is successful, the client returns an `array`.
   ]
 ];
 ```
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns an `Alphagov\Notifications\Exception\ApiException` object containing the relevant error code:
 


### PR DESCRIPTION
This changes the headings so that there is only one H1 heading. This is part of the work to make the tech docs headings accessible.