### PR TITLE
Update link and link text for accessibility

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -639,7 +639,7 @@ You can only get the status of messages that are 7 days old or newer.
 |:---|:---|
 |Pending virus check|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
 |Virus scan failed|GOV.UK Notify found a potential virus in the precompiled letter file.|
-|Validation failed|Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify PDF letter specification](https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.4.pdf) for more information.|
+|Validation failed|Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.|
 
 ### Get the status of one message
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -549,7 +549,7 @@ $reference = 'STRING';
 
 ##### pdf_data (required)
 
-The precompiled letter must be a PDF file which meets [the GOV.UK Notify PDF letter specification](https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.4.pdf). The method sends the contents of the file to GOV.UK Notify.
+The precompiled letter must be a PDF file which meets [the GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification). The method sends the contents of the file to GOV.UK Notify.
 
 ```php
 $pdf_data = file_get_contents("path/to/pdf_file");


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->
This PR updates the link and link text so users go to the new 'Letter specification' page, instead of the PDF.

We're doing this because of the work done in: https://github.com/alphagov/notifications-admin/pull/3624

This is part of our accessibility compliance work.


## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve updated the documentation (in `DOCUMENTATION.md` and `CHANGELOG.md`)
- [ ] I’ve bumped the version number (`const VERSION` in `src/Client.php`)
