### PR TITLE
suppress composer prompts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,3 +14,6 @@ RUN \
 RUN curl --silent --show-error https://getcomposer.org/installer | php -- --install-dir /usr/local/bin --filename composer
 
 WORKDIR /var/project
+
+ENV COMPOSER_ALLOW_SUPERUSER=1
+ENV COMPOSER_NO_INTERACTION=1


### PR DESCRIPTION
previously it was waiting on concourse for an interactive prompt that
would never be answered about if its okay to be superuser - since we're
in docker it's okay to be superuser

suppress that error, also suppress any other prompts as concourse can't
deal with them
