### PR TITLE
Bump firebase/php-jwt to ^v6.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   ],
   "require": {
     "php": ">=5.4",
-    "firebase/php-jwt": "^5.0",
+    "firebase/php-jwt": "^v6.1.0",
     "guzzlehttp/psr7" : "^1.2"
   },
   "require-dev": {

--- a/spec/unit/Authentication/JsonWebTokenSpec.php
+++ b/spec/unit/Authentication/JsonWebTokenSpec.php
@@ -1,6 +1,7 @@
 <?php
 namespace spec\unit\Alphagov\Notifications\Authentication;
 
+use Firebase\JWT\Key;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use PhpSpec\Exception\Example\FailureException;
@@ -93,7 +94,8 @@ class JsonWebTokenSpec extends ObjectBehavior
                 try {
 
                     JWT::$leeway = 5; // $leeway in seconds
-                    $decoded = JWT::decode($token, self::API_KEY, array('HS256'));
+                    $key = new Key(self::API_KEY, 'HS256');
+                    $decoded = JWT::decode($token, $key);
 
                 } catch( SignatureInvalidException $e ){
 
@@ -133,7 +135,8 @@ class JsonWebTokenSpec extends ObjectBehavior
                 try {
 
                     JWT::$leeway = 5; // $leeway in seconds
-                    JWT::decode($token, self::API_KEY, array('HS256'));
+                    $key = new Key(self::API_KEY, 'HS256');
+                    JWT::decode($token, $key);
 
                 } catch( SignatureInvalidException $e ){
 

--- a/src/Authentication/JsonWebToken.php
+++ b/src/Authentication/JsonWebToken.php
@@ -73,7 +73,7 @@ class JsonWebToken implements JWTAuthenticationInterface {
 
         $claims = $this->generateClaims();
 
-        return JWT::encode( $claims, $this->key );
+        return JWT::encode( $claims, $this->key, 'HS256' );
 
     }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -25,7 +25,7 @@ class Client {
      * @const string Current version of this client.
      * This follows Semantic Versioning (http://semver.org/)
      */
-    const VERSION = '3.3.0';
+    const VERSION = '4.0.0';
 
     /**
      * @const string The API endpoint for Notify production.

--- a/src/Client.php
+++ b/src/Client.php
@@ -25,7 +25,7 @@ class Client {
      * @const string Current version of this client.
      * This follows Semantic Versioning (http://semver.org/)
      */
-    const VERSION = '3.2.0';
+    const VERSION = '3.3.0';
 
     /**
      * @const string The API endpoint for Notify production.


### PR DESCRIPTION
## What problem does the pull request solve?
Fixes https://security.snyk.io/vuln/SNYK-PHP-FIREBASEPHPJWT-2434829. This is a vulnerability flagged in our repo - https://github.com/ministryofjustice/opg-digideps.

I'm hoping there aren't any other breaking changes in moving from v5 -> v6 but as I can't run the integration tests without valid creds I had to just rely on unit tests (which are passing now). Happy to pair with a Notify dev to get the fix out if required, just let me know.

## Checklist
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve updated the documentation (in `DOCUMENTATION.md` and `CHANGELOG.md`)
- [x] I’ve bumped the version number (`const VERSION` in `src/Client.php`)
