### PR TITLE
Bump php requirement in composer.json and make version 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [4.0.1] - 2022-04-07
+### Added
+
+* Added explicit requirement for PHP versions < 7.1 to composer.json
+
+See https://github.com/alphagov/notifications-php-client/pull/107 for further context
+
 ## [4.0.0] - 2022-04-06
 ### Removed
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   ],
   "require": {
-    "php": ">=5.4",
+    "php": ">=7.1",
     "firebase/php-jwt": "^v6.1.0",
     "guzzlehttp/psr7" : "^1.2"
   },

--- a/src/Client.php
+++ b/src/Client.php
@@ -25,7 +25,7 @@ class Client {
      * @const string Current version of this client.
      * This follows Semantic Versioning (http://semver.org/)
      */
-    const VERSION = '4.0.0';
+    const VERSION = '4.0.1';
 
     /**
      * @const string The API endpoint for Notify production.


### PR DESCRIPTION
This was missed in https://github.com/alphagov/notifications-php-client/pull/109
which raised the requirement on PHP versions but I forgot to add
the requirement to the composer.json file.

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [x ] I’ve updated the documentation (in `DOCUMENTATION.md` and `CHANGELOG.md`)
- [x ] I’ve bumped the version number (`const VERSION` in `src/Client.php`)
