### PR TITLE
Remove documentation for cURL support

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -4,7 +4,7 @@ This documentation is for developers interested in using the GOV.UK Notify PHP c
 
 ## Set up the client
 
-The Notify PHP Client is based on a [PSR-7 HTTP model](https://www.php-fig.org/psr/psr-7/) [external link]. To install it, you must select your preferred HTTP client. You can follow these instructions to use [Guzzle v6 and v5](http://docs.guzzlephp.org/en/stable/) and [cURL](http://php.net/manual/en/book.curl.php) [external links].
+The Notify PHP Client is based on a [PSR-7 HTTP model](https://www.php-fig.org/psr/psr-7/) [external link]. To install it, you must select your preferred PSR-7 compatible HTTP client. You can follow these instructions to use [Guzzle v6 and v5](http://docs.guzzlephp.org/en/stable/)[external link].
 
 ### Guzzle v6
 
@@ -53,31 +53,6 @@ To get an API key, [sign in to GOV.UK Notify](https://www.notifications.service.
 
 To get an API key, [sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __API integration__ page. You can find more information in the [API keys](#api-keys) section of this documentation.
 
-### cURL
-
-1. Use [Composer](https://getcomposer.org/)  [external link] to install the GOV.UK Notify PHP client. Run the following in the command line:
-
-    ```sh
-    composer require php-http/curl-client php-http/message alphagov/notifications-php-client
-    ```
-
-You can now use the [autoloader](https://getcomposer.org/doc/01-basic-usage.md#autoloading) [external link] to download the GOV.UK Notify PHP client.
-
-1. Add the following code to your application to create a new instance of the client:
-
-    ```
-    $notifyClient = new \Alphagov\Notifications\Client([
-        'apiKey'        => '{your api key}',
-        'httpClient'    => new \Http\Client\Curl\Client(
-            new \Http\Message\MessageFactory\GuzzleMessageFactory,
-            new \Http\Message\StreamFactory\GuzzleStreamFactory
-        ),
-    ]);
-    ```
-
-1. Run `$notifyClient` to access the GOV.UK Notify API.
-
-To get an API key, [sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __API integration__ page. You can find more information in the [API keys](#api-keys) section of this documentation.
 
 ## Send a message
 


### PR DESCRIPTION
Support for cURL was removed in version 3.0.0 of this client
without us realising.

To make the docs correct, we are therefore removing the instructions
on how to use it.

We may decide to add back in cURL support but haven't commited to
doing so right at this point.

For more context, see:
https://github.com/alphagov/notifications-php-client/issues/111#issuecomment-1165767985

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve updated the documentation (in `DOCUMENTATION.md` and `CHANGELOG.md`)
- [ ] I’ve bumped the version number (`const VERSION` in `src/Client.php`)
