### PR TITLE
Run tests against PHP 8.0 rather than EOL 7.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-cli
+FROM php:8.0-cli
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
As per https://www.php.net/supported-versions.php, PHP 7.3 is about
to stop receiving security support in 4 months time. It is essentially
end of life.

Therefore let us run our tests against the next lowest version of
PHP that is still supported as hopefully most users are now
using this.

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve updated the documentation (in `DOCUMENTATION.md` and `CHANGELOG.md`)
- [ ] I’ve bumped the version number (`const VERSION` in `src/Client.php`)
