### PR TITLE
Remove unecessary curl related libraries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,9 @@
   "require-dev": {
     "phpspec/phpspec": "^5.0",
     "php-http/message": "^1.1",
-    "php-http/curl-client": "*",
     "php-http/mock-client": "*",
     "php-http/socket-client": "2.0.0-beta1",
     "php-http/guzzle6-adapter": "*"
-  },
-  "suggest": {
-    "ext-curl": "To send requests using cURL"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
https://github.com/alphagov/notifications-php-client/pull/112
this removed the documentation for curl but I forgot to remove
some libraries that we no longer need to use

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve updated the documentation (in `DOCUMENTATION.md` and `CHANGELOG.md`)
- [ ] I’ve bumped the version number (`const VERSION` in `src/Client.php`)
