### PR TITLE
Update dev dependencies to support PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,16 +15,16 @@
     }
   ],
   "require": {
-    "php": ">=7.1",
+    "php": "^7.1|^8.0",
     "firebase/php-jwt": "^v6.1.0",
     "guzzlehttp/psr7" : "^1.2"
   },
   "require-dev": {
-    "phpspec/phpspec": "^5.0",
+    "phpspec/phpspec": "^5.0|^7.2",
     "php-http/message": "^1.1",
     "php-http/curl-client": "*",
     "php-http/mock-client": "*",
-    "php-http/socket-client": "2.0.0-beta1",
+    "php-http/socket-client": "^2.1.0",
     "php-http/guzzle6-adapter": "*"
   },
   "suggest": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -25,7 +25,7 @@ class Client {
      * @const string Current version of this client.
      * This follows Semantic Versioning (http://semver.org/)
      */
-    const VERSION = '4.0.1';
+    const VERSION = '4.1.0';
 
     /**
      * @const string The API endpoint for Notify production.


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

Currently dev dependencies can not be installed on PHP 8 environments as they are out of date and don't support this version.

This change updates the dev dependencies required to run the test suite on PHP 8. The test suite passes on PHP 8.0 & 8.1 with no changes to the suite.

There are no code changes to the client or its non-dev dependencies so this is not a breaking change. As such, I have bumped the client to `v4.1.0`.

Maintains backwards compatibility down to PHP 7.1 by allowing phpspec ^5.0.

Installing dependencies in environments with PHP >7.1 will get phpspec ^7.2.

Tested with PHP versions 7.1, 7.2, 7.3, 8.0 & 8.1.


## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ x] I’ve bumped the version number (`const VERSION` in `src/Client.php`)
