### PR TITLE
Add support for send a file security features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [4.2.0] - 2022-09-27
+### Added
+
+* Add support for new security features when sending a file by email:
+  * `confirm_email_before_download` can be set to `true` to require the user to enter their email address before accessing the file.
+  * `retention_period` can be set to `<1-78> weeks` to set how long the file should be made available.
+
 ## [4.1.0] - 2022-07-01
 ### Added
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -266,9 +266,16 @@ You can leave out this argument if your service only has one email reply-to addr
 
 To send a file by email, add a placeholder to the template then upload a file. The placeholder will contain a secure link to download the file.
 
-The file will be available for the recipient to download for 18 months.
-
 The links are unique and unguessable. GOV.UK Notify cannot access or decrypt your file.
+
+Your file will be available to download for a default period of 78 weeks (18 months). From 29 March 2023 we will reduce this to 26 weeks (6 months) for all new files. Files sent before 29 March will not be affected.
+
+To help protect your files you can also:
+
+* ask recipients to confirm their email address before downloading
+* choose the length of time that a file is available to download
+
+To turn these features on or off, you will need version 4.2.0 of the PHP client library or a more recent version.
 
 #### Add contact details to the file download page
 
@@ -282,9 +289,9 @@ The links are unique and unguessable. GOV.UK Notify cannot access or decrypt you
 1. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in).
 1. Go to the __Templates__ page and select the relevant email template.
 1. Select __Edit__.
-1. Add a placeholder to the email template using double brackets. For example:
+1. Add a placeholder to the email template using double brackets. For example: "Download your file at: ((link_to_file))"
 
-"Download your file at: ((link_to_file))"
+Your email should also tell recipients how long the file will be available to download.
 
 #### Upload your file
 
@@ -332,6 +339,100 @@ catch (ApiException $e){}
 catch (InvalidArgumentException $e){}
 ```
 
+#### Ask recipients to confirm their email address before they can download the file
+
+This new security feature is optional. You should use it if you send files that are sensitive - for example, because they contain personal information about your users.
+
+When a recipient clicks the link in the email you’ve sent them, they have to enter their email address. Only someone who knows the recipient’s email address can download the file.
+
+From 29 March 2023, we will turn this feature on by default for every file you send. Files sent before 29 March will not be affected.
+
+##### Turn on email address check
+
+To use this feature before 29 March 2023 you will need version 4.2.0 of the PHP client library, or a more recent version.
+
+To make the recipient confirm their email address before downloading the file, set the `confirm_email_before_download` flag to `true`.
+
+You will not need to do this after 29 March.
+
+```php
+try {
+    $file_data = file_get_contents('/path/to/my/file.pdf');
+
+    $response = $notifyClient->sendEmail(
+        'betty@example.com',
+        'df10a23e-2c0d-4ea5-87fb-82e520cbf93c',
+        [
+            'name' => 'Betty Smith',
+            'dob'  => '12 July 1968',
+            'link_to_file' => $notifyClient->prepareUpload( $file_dat, false, true )
+        ]
+    );
+}
+catch (ApiException $e){}
+catch (InvalidArgumentException $e){}
+```
+
+##### Turn off email address check (not recommended)
+
+If you do not want to use this feature after 29 March 2023, you can turn it off on a file-by-file basis.
+
+To do this you will need version 4.2.0 of the PHP client library, or a more recent version.
+
+You should not turn this feature off if you send files that contain:
+
+* personally identifiable information
+* commercially sensitive information
+* information classified as ‘OFFICIAL’ or ‘OFFICIAL-SENSITIVE’ under the [Government Security Classifications](https://www.gov.uk/government/publications/government-security-classifications) policy
+
+To let the recipient download the file without confirming their email address, set the `confirm_email_before_download` flag to `false`.
+
+```php
+try {
+    $file_data = file_get_contents('/path/to/my/file.pdf');
+
+    $response = $notifyClient->sendEmail(
+        'betty@example.com',
+        'df10a23e-2c0d-4ea5-87fb-82e520cbf93c',
+        [
+            'name' => 'Betty Smith',
+            'dob'  => '12 July 1968',
+            'link_to_file' => $notifyClient->prepareUpload( $file_data, false, false )
+        ]
+    );
+}
+catch (ApiException $e){}
+catch (InvalidArgumentException $e){}
+```
+
+#### Choose the length of time that a file is available to download
+
+Set the number of weeks you want the file to be available using the `retentionPeriod` key.
+
+You can choose any value between 1 week and 78 weeks.
+
+To use this feature will need version 4.2.0 of the PHP client library, or a more recent version.
+
+If you do not choose a value, the file will be available for the default period of 78 weeks (18 months).
+
+```php
+try {
+    $file_data = file_get_contents('/path/to/my/file.pdf');
+
+    $response = $notifyClient->sendEmail(
+        'betty@example.com',
+        'df10a23e-2c0d-4ea5-87fb-82e520cbf93c',
+        [
+            'name' => 'Betty Smith',
+            'dob'  => '12 July 1968',
+            'link_to_file' => $notifyClient->prepareUpload( $file_data, false, null, "52 weeks" )
+        ]
+    );
+}
+catch (ApiException $e){}
+catch (InvalidArgumentException $e){}
+```
+
 #### Response
 
 If the request to the client is successful, the client returns an `array`:
@@ -364,6 +465,8 @@ If the request is not successful, the client returns an `Alphagov\Notifications\
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient using a team-only API key"`<br>`}]`|Use the correct type of [API key](#api-keys).|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"`<br>`}]`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode).|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Unsupported file type '(FILE TYPE)'. Supported types are: '(ALLOWED TYPES)'"`<br>`}]`|Wrong file type. You can only upload .pdf, .csv, .txt, .doc, .docx, .xlsx, .rtf or .odt files.|
+|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Unsupported value for retention_period '(PERIOD)'. Supported periods are from 1 to 78 weeks."`<br>`}]`|Choose a period between 1 and 78 weeks|
+|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Unsupported value for confirm_email_before_download: '(VALUE)'. Use a boolean true or false value."`<br>`}]`|Use either true or false|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "File did not pass the virus scan"`<br>`}]`|The file contains a virus.|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Send files by email has not been set up - add contact details for your service at https://www.notifications.service.gov.uk/services/(SERVICE ID)/service-settings/send-files-by-email"`<br>`}]`|See how to [add contact details to the file download page](#add-contact-details-to-the-file-download-page)|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can only send a file by email"`<br>`}]`|Make sure you are using an email template|

--- a/spec/integration/ClientSpec.php
+++ b/spec/integration/ClientSpec.php
@@ -153,6 +153,28 @@ class ClientSpec extends ObjectBehavior
 
     }
 
+    function it_receives_the_expected_response_when_sending_an_email_notification_with_an_uploaded_csv_using_email_confirmation_flow_and_retention_period(){
+
+        $file_contents = file_get_contents( './spec/integration/basic_csv.csv' );
+
+        $response = $this->sendEmail( getenv('FUNCTIONAL_TEST_EMAIL'), getenv('EMAIL_TEMPLATE_ID'), [
+            "name" => $this->prepareUpload( $file_contents, TRUE, TRUE, '4 weeks' )
+        ]);
+
+        $response->shouldBeArray();
+        $response->shouldHaveKey( 'id' );
+        $response['id']->shouldBeString();
+
+        $response->shouldHaveKey( 'reference' );
+
+        $response->shouldHaveKey( 'content' );
+        $response['content']->shouldBeArray();;
+        $response['content']->shouldHaveKey( 'body' );
+        $response['content']['body']->shouldBeString();
+        $response['content']['body']->shouldContain("https://documents.");
+
+    }
+
     function it_receives_the_expected_response_when_looking_up_an_email_notification() {
 
       // Requires the 'it_receives_the_expected_response_when_sending_an_email_notification' test to have completed successfully

--- a/spec/integration/basic_csv.csv
+++ b/spec/integration/basic_csv.csv
@@ -1,0 +1,4 @@
+id,name
+1,leo
+2,david
+3,sam

--- a/spec/unit/ClientSpec.php
+++ b/spec/unit/ClientSpec.php
@@ -721,12 +721,17 @@ class ClientSpec extends ObjectBehavior
 
 
     function it_generates_the_expected_request_when_preparing_file_for_upload(){
-        $this->prepareUpload('%PDF-1.5 testpdf')->shouldReturn( [ 'file' => 'JVBERi0xLjUgdGVzdHBkZg==', 'is_csv' => false ] );
+        $this->prepareUpload('%PDF-1.5 testpdf')->shouldReturn( [ 'file' => 'JVBERi0xLjUgdGVzdHBkZg==', 'is_csv' => false, 'confirm_email_before_download' => NULL, 'retention_period' => NULL ] );
     }
 
 
     function it_generates_the_expected_request_when_preparing_a_csv_file_for_upload(){
-        $this->prepareUpload('%PDF-1.5 testpdf', true)->shouldReturn( [ 'file' => 'JVBERi0xLjUgdGVzdHBkZg==', 'is_csv' => true ] );
+        $this->prepareUpload('%PDF-1.5 testpdf', true)->shouldReturn( [ 'file' => 'JVBERi0xLjUgdGVzdHBkZg==', 'is_csv' => true, 'confirm_email_before_download' => NULL, 'retention_period' => NULL ] );
+    }
+
+
+    function it_generates_the_expected_request_when_configuring_email_confirmation_and_retention(){
+        $this->prepareUpload('%PDF-1.5 testpdf', true, true, "1 weeks")->shouldReturn( [ 'file' => 'JVBERi0xLjUgdGVzdHBkZg==', 'is_csv' => true, 'confirm_email_before_download' => true, 'retention_period' => '1 weeks' ] );
     }
 
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -25,7 +25,7 @@ class Client {
      * @const string Current version of this client.
      * This follows Semantic Versioning (http://semver.org/)
      */
-    const VERSION = '4.1.0';
+    const VERSION = '4.2.0';
 
     /**
      * @const string The API endpoint for Notify production.
@@ -393,17 +393,24 @@ class Client {
      *
      * @param string $file_contents
      * @param bool $is_csv
+     * @param bool $confirm_email_before_download
+     * @param string $retention_period
      *
      * @return array
      */
-    public function prepareUpload( $file_contents, $is_csv = false ){
+    public function prepareUpload( $file_contents, $is_csv = false, $confirm_email_before_download = NULL, $retention_period = NULL ){
         if ( strlen($file_contents) > ( 2 * 1024 * 1024 )) {
             throw new Exception\InvalidArgumentException( 'File is larger than 2MB.' );
         }
-        return [
+        $data = [
             "file" => base64_encode($file_contents),
             "is_csv" => $is_csv
         ];
+
+        $data['confirm_email_before_download'] = $confirm_email_before_download;
+        $data['retention_period'] = $retention_period;
+
+        return $data;
     }
 
     //------------------------------------------------------------------------------------


### PR DESCRIPTION
Adds optional parameters `confirm_email_before_download` and `retention_period` to the `prepare_upload` helper, to access new security features when sending a file by email.

Bumps the client version to 5.4.0

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve updated the documentation (in `DOCUMENTATION.md` and `CHANGELOG.md`)
- [x] I’ve bumped the version number (`const VERSION` in `src/Client.php`)
