### PR TITLE
PSR7 compatibility 

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -11,7 +11,7 @@ The Notify PHP Client is based on a [PSR-7 HTTP model](https://www.php-fig.org/p
 1. Use [Composer](https://getcomposer.org/)  [external link] to install the GOV.UK Notify PHP client. Run the following in the command line:
 
     ```sh
-    composer require php-http/guzzle6-adapter alphagov/notifications-php-client
+    composer require php-http/guzzle7-adapter alphagov/notifications-php-client
     ```
 
     You can now use the [autoloader](https://getcomposer.org/doc/01-basic-usage.md#autoloading) [external link] to download the GOV.UK Notify PHP client.
@@ -21,7 +21,7 @@ The Notify PHP Client is based on a [PSR-7 HTTP model](https://www.php-fig.org/p
     ```
     $notifyClient = new \Alphagov\Notifications\Client([
         'apiKey' => '{your api key}',
-        'httpClient' => new \Http\Adapter\Guzzle6\Client
+        'httpClient' => new \Http\Adapter\Guzzle7\Client
     ]);
     ```
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -6,7 +6,7 @@ This documentation is for developers interested in using the GOV.UK Notify PHP c
 
 The Notify PHP Client is based on a [PSR-7 HTTP model](https://www.php-fig.org/psr/psr-7/) [external link]. To install it, you must select your preferred PSR-7 compatible HTTP client. You can follow these instructions to use [Guzzle v6 and v5](http://docs.guzzlephp.org/en/stable/)[external link].
 
-### Guzzle v6
+### Guzzle v7
 
 1. Use [Composer](https://getcomposer.org/)  [external link] to install the GOV.UK Notify PHP client. Run the following in the command line:
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "php": "^7.1|^8.0",
     "firebase/php-jwt": "^v6.1.0",
-    "guzzlehttp/psr7" : "^1.2"
+    "guzzlehttp/psr7" : "^2.4.3"
   },
   "require-dev": {
     "phpspec/phpspec": "^5.0|^7.2",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "php-http/message": "^1.1",
     "php-http/mock-client": "*",
     "php-http/socket-client": "^2.1.0",
-    "php-http/guzzle6-adapter": "*"
+    "php-http/guzzle7-adapter": "^1.0"
   },
   "autoload": {
     "psr-4": {

--- a/spec/integration/ClientSpec.php
+++ b/spec/integration/ClientSpec.php
@@ -13,6 +13,7 @@ use Alphagov\Notifications\Exception\ApiException;
 use GuzzleHttp\Psr7\Uri;
 use Http\Client\HttpClient as HttpClientInterface;
 use GuzzleHttp\Psr7\Response;
+use Http\Adapter\Guzzle7\Client as Guzzle7Client;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -32,7 +33,7 @@ class ClientSpec extends ObjectBehavior
       $this->beConstructedWith([
             'baseUrl'       => getenv('NOTIFY_API_URL'),
             'apiKey'        => getenv('API_KEY'),
-            'httpClient'    => new \Http\Adapter\Guzzle6\Client
+            'httpClient'    => new Guzzle7Client()
         ]);
 
     }
@@ -599,7 +600,7 @@ class ClientSpec extends ObjectBehavior
       $this->beConstructedWith([
         'baseUrl'       => getenv('NOTIFY_API_URL'),
         'apiKey'        => getenv('API_SENDING_KEY'),
-        'httpClient'    => new \Http\Adapter\Guzzle6\Client
+        'httpClient'    => new Guzzle7Client(),
       ]);
 
       $response = $this->sendSms(
@@ -729,7 +730,7 @@ class ClientSpec extends ObjectBehavior
       $this->beConstructedWith([
         'baseUrl'       => getenv('NOTIFY_API_URL'),
         'apiKey'        => getenv('INBOUND_SMS_QUERY_KEY'),
-        'httpClient'    => new \Http\Adapter\Guzzle6\Client
+        'httpClient'    => new Guzzle7Client(),
       ]);
 
       $response = $this->listReceivedTexts();

--- a/spec/integration/ClientSpec.php
+++ b/spec/integration/ClientSpec.php
@@ -13,7 +13,6 @@ use Alphagov\Notifications\Exception\ApiException;
 use GuzzleHttp\Psr7\Uri;
 use Http\Client\HttpClient as HttpClientInterface;
 use GuzzleHttp\Psr7\Response;
-use Http\Adapter\Guzzle7\Client as Guzzle7Client;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -33,7 +32,7 @@ class ClientSpec extends ObjectBehavior
       $this->beConstructedWith([
             'baseUrl'       => getenv('NOTIFY_API_URL'),
             'apiKey'        => getenv('API_KEY'),
-            'httpClient'    => new Guzzle7Client()
+            'httpClient'    => new \Http\Adapter\Guzzle7\Client
         ]);
 
     }
@@ -600,7 +599,7 @@ class ClientSpec extends ObjectBehavior
       $this->beConstructedWith([
         'baseUrl'       => getenv('NOTIFY_API_URL'),
         'apiKey'        => getenv('API_SENDING_KEY'),
-        'httpClient'    => new Guzzle7Client(),
+        'httpClient'    => new \Http\Adapter\Guzzle7\Client
       ]);
 
       $response = $this->sendSms(
@@ -730,7 +729,7 @@ class ClientSpec extends ObjectBehavior
       $this->beConstructedWith([
         'baseUrl'       => getenv('NOTIFY_API_URL'),
         'apiKey'        => getenv('INBOUND_SMS_QUERY_KEY'),
-        'httpClient'    => new Guzzle7Client(),
+        'httpClient'    => new \Http\Adapter\Guzzle7\Client
       ]);
 
       $response = $this->listReceivedTexts();

--- a/src/Client.php
+++ b/src/Client.php
@@ -25,7 +25,7 @@ class Client {
      * @const string Current version of this client.
      * This follows Semantic Versioning (http://semver.org/)
      */
-    const VERSION = '4.2.0';
+    const VERSION = '4.3.0';
 
     /**
      * @const string The API endpoint for Notify production.

--- a/src/Client.php
+++ b/src/Client.php
@@ -25,7 +25,7 @@ class Client {
      * @const string Current version of this client.
      * This follows Semantic Versioning (http://semver.org/)
      */
-    const VERSION = '4.3.0';
+    const VERSION = '5.0.0';
 
     /**
      * @const string The API endpoint for Notify production.


### PR DESCRIPTION
## What problem does the pull request solve?
This solves the PSR7 compliance errors by updating the version of `guzzlehttp/psr7`.

The guzzle6 adapter still caused errors even after updating the the latest version, so it was also necessary to switch this with guzzle7.

## Checklist

- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [x] I’ve updated the documentation (in `DOCUMENTATION.md` and `CHANGELOG.md`)
- [x] I’ve bumped the version number (`const VERSION` in `src/Client.php`)
