### PR TITLE
Move to guzzle7-adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [5.0.0] - 2022-11-25
+### Removed
+
+* Removed guzzle5-adapter and guzzle6-adapter documentation and support; this version now supports any PSR-7 compatible client library. Our documentation provides examples for using guzzle7.
+
 ## [4.2.0] - 2022-09-27
 ### Added
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -27,33 +27,6 @@ The Notify PHP Client is based on a [PSR-7 HTTP model](https://www.php-fig.org/p
 
 To get an API key, [sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __API integration__ page. You can find more information in the [API keys](#api-keys) section of this documentation.
 
-### Guzzle v5
-
-1. Use [Composer](https://getcomposer.org/)  [external link] to install the GOV.UK Notify PHP client. Run the following in the command line:
-
-    ```sh
-    composer require php-http/guzzle5-adapter php-http/message alphagov/notifications-php-client
-    ```
-
-    You can now use the [autoloader](https://getcomposer.org/doc/01-basic-usage.md#autoloading) [external link] to download the GOV.UK Notify PHP client.
-
-1. Add the following code to your application to create a new instance of the client:
-
-    ```
-    $notifyClient = new \Alphagov\Notifications\Client([
-        'apiKey'        => '{your api key}',
-        'httpClient'    => new \Http\Adapter\Guzzle5\Client(
-            new \GuzzleHttp\Client,
-            new \Http\Message\MessageFactory\GuzzleMessageFactory
-        ),
-    ]);
-    ```
-
-1. Run `$notifyClient` to access the GOV.UK Notify API.
-
-To get an API key, [sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __API integration__ page. You can find more information in the [API keys](#api-keys) section of this documentation.
-
-
 ## Send a message
 
 You can use GOV.UK Notify to send text messages, emails and letters.

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -4,14 +4,14 @@ This documentation is for developers interested in using the GOV.UK Notify PHP c
 
 ## Set up the client
 
-The Notify PHP Client is based on a [PSR-7 HTTP model](https://www.php-fig.org/psr/psr-7/) [external link]. To install it, you must select your preferred PSR-7 compatible HTTP client. You can follow these instructions to use [Guzzle v6 and v5](http://docs.guzzlephp.org/en/stable/)[external link].
+The Notify PHP Client is based on a [PSR-7 HTTP model](https://www.php-fig.org/psr/psr-7/) [external link]. To install it, you must select your preferred PSR-7 compatible HTTP client. You can follow these instructions to use [Guzzle v7](https://docs.guzzlephp.org/en/7.0/)[external link].
 
-### Guzzle v6
+### Guzzle v7
 
 1. Use [Composer](https://getcomposer.org/)  [external link] to install the GOV.UK Notify PHP client. Run the following in the command line:
 
     ```sh
-    composer require php-http/guzzle6-adapter alphagov/notifications-php-client
+    composer require php-http/guzzle7-adapter alphagov/notifications-php-client
     ```
 
     You can now use the [autoloader](https://getcomposer.org/doc/01-basic-usage.md#autoloading) [external link] to download the GOV.UK Notify PHP client.
@@ -21,7 +21,7 @@ The Notify PHP Client is based on a [PSR-7 HTTP model](https://www.php-fig.org/p
     ```
     $notifyClient = new \Alphagov\Notifications\Client([
         'apiKey' => '{your api key}',
-        'httpClient' => new \Http\Adapter\Guzzle6\Client
+        'httpClient' => new \Http\Adapter\Guzzle7\Client
     ]);
     ```
 

--- a/composer.json
+++ b/composer.json
@@ -15,16 +15,16 @@
     }
   ],
   "require": {
-    "php": "^7.1|^8.0",
+    "php": "^7.2|^8.0",
     "firebase/php-jwt": "^v6.1.0",
-    "guzzlehttp/psr7" : "^1.2"
+    "guzzlehttp/psr7": "^2.1.1"
   },
   "require-dev": {
     "phpspec/phpspec": "^5.0|^7.2",
     "php-http/message": "^1.1",
     "php-http/mock-client": "*",
     "php-http/socket-client": "^2.1.0",
-    "php-http/guzzle6-adapter": "*"
+    "php-http/guzzle7-adapter": "^1.0"
   },
   "autoload": {
     "psr-4": {

--- a/spec/integration/ClientSpec.php
+++ b/spec/integration/ClientSpec.php
@@ -32,7 +32,7 @@ class ClientSpec extends ObjectBehavior
       $this->beConstructedWith([
             'baseUrl'       => getenv('NOTIFY_API_URL'),
             'apiKey'        => getenv('API_KEY'),
-            'httpClient'    => new \Http\Adapter\Guzzle6\Client
+            'httpClient'    => new \Http\Adapter\Guzzle7\Client
         ]);
 
     }
@@ -599,7 +599,7 @@ class ClientSpec extends ObjectBehavior
       $this->beConstructedWith([
         'baseUrl'       => getenv('NOTIFY_API_URL'),
         'apiKey'        => getenv('API_SENDING_KEY'),
-        'httpClient'    => new \Http\Adapter\Guzzle6\Client
+        'httpClient'    => new \Http\Adapter\Guzzle7\Client
       ]);
 
       $response = $this->sendSms(
@@ -729,7 +729,7 @@ class ClientSpec extends ObjectBehavior
       $this->beConstructedWith([
         'baseUrl'       => getenv('NOTIFY_API_URL'),
         'apiKey'        => getenv('INBOUND_SMS_QUERY_KEY'),
-        'httpClient'    => new \Http\Adapter\Guzzle6\Client
+        'httpClient'    => new \Http\Adapter\Guzzle7\Client
       ]);
 
       $response = $this->listReceivedTexts();

--- a/src/Client.php
+++ b/src/Client.php
@@ -25,7 +25,7 @@ class Client {
      * @const string Current version of this client.
      * This follows Semantic Versioning (http://semver.org/)
      */
-    const VERSION = '4.2.0';
+    const VERSION = '5.0.0';
 
     /**
      * @const string The API endpoint for Notify production.


### PR DESCRIPTION
Kicked off from https://github.com/alphagov/notifications-php-client/pull/119

## What problem does the pull request solve?
Update from guzzle5-adapter and guzzle6-adapter to guzzle7-adapter and adjust documentation accordingly.

Release as a major version bump to v5.0.0 to indicate the backwards-incompatible change.

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [x] I’ve updated the documentation (in `DOCUMENTATION.md` and `CHANGELOG.md`)
- [x] I’ve bumped the version number (`const VERSION` in `src/Client.php`)
