### PR TITLE
fix php composer issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,11 @@
   "minimum-stability": "stable",
   "license": "MIT",
   "type": "library",
+  "config": {
+    "allow-plugins": {
+      "php-http/discovery": false
+    }
+  },
   "authors": [
     {
       "name": "GOV UK Notify",


### PR DESCRIPTION
so theres some kind of php plugin subdependency that causes issues

https://github.com/php-http/discovery/issues/213

a contributor commented here:

https://github.com/php-http/discovery/issues/213#issuecomment-1424271561

> The right solution is to disable the plugin, you likely don't need it anyway in your CI:

they've now tweaked composer to allow you to autodisable plugins - we might want to look in to this if this happens again?

https://github.com/composer/composer/pull/11315