### PR TITLE
Allow setting custom filenames for documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [6.0.0] - 2023-12-27
+
+* Removes the `is_csv` parameter from `prepareUpload`
+* Adds a `filename` parameter to `prepareUpload` to set the filename of a document when it is downloaded. See the documentation for more information.
+
 ## [5.0.0] - 2022-11-25
 ### Removed
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -292,13 +292,20 @@ catch (InvalidArgumentException $e){}
 
 #### Set the filename
 
-You can provide a filename to set when the recipient downloads the file. If this is not provided, a random filename will be generated.
+To do this you will need version 6.0.0 of the PHP client library, or a more recent version.
 
-Choosing a sensible filename can help users understand what the file contains, and find it again later.
+You should provide a filename when you upload your file.
 
-You do not have to set this, but we strongly recommend it.
+The filename should tell the recipient what the file contains. A memorable filename can help the recipient to find the file again later.
 
-The filename must include the correct file extension, such as `.csv` for a CSV file. If you include the wrong file extension, users may not be able to open your file.
+The filename must end with a file extension. For example, `.csv` for a CSV file. If you include the wrong file extension, recipients may not be able to open your file.
+
+If you do not provide a filename for your file, Notify will:
+
+* generate a random filename
+* try to add the correct file extension
+
+If Notify cannot add the correct file extension, recipients may not be able to open your file.
 
 ```php
 try {

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -290,9 +290,15 @@ catch (ApiException $e){}
 catch (InvalidArgumentException $e){}
 ```
 
-##### CSV Files
+#### Set the filename
 
-Uploads for CSV files should use the `is_csv` parameter on the `prepareUpload()` helper method.  For example:
+You can provide a filename to set when the recipient downloads the file. If this is not provided, a random filename will be generated.
+
+Choosing a sensible filename can help users understand what the file contains, and find it again later.
+
+You do not have to set this, but we strongly recommend it.
+
+The filename must include the correct file extension, such as `.csv` for a CSV file. If you include the wrong file extension, users may not be able to open your file.
 
 ```php
 try {
@@ -304,7 +310,7 @@ try {
         [
             'name' => 'Betty Smith',
             'dob'  => '12 July 1968',
-            'link_to_file' => $notifyClient->prepareUpload( $file_data, true )
+            'link_to_file' => $notifyClient->prepareUpload( $file_data, "report.csv" )
         ]
     );
 }
@@ -342,7 +348,7 @@ try {
         [
             'name' => 'Betty Smith',
             'dob'  => '12 July 1968',
-            'link_to_file' => $notifyClient->prepareUpload( $file_data, false, false )
+            'link_to_file' => $notifyClient->prepareUpload( $file_data, null, false )
         ]
     );
 }
@@ -375,7 +381,7 @@ try {
         [
             'name' => 'Betty Smith',
             'dob'  => '12 July 1968',
-            'link_to_file' => $notifyClient->prepareUpload( $file_data, false, null, "52 weeks" )
+            'link_to_file' => $notifyClient->prepareUpload( $file_data, null, null, "52 weeks" )
         ]
     );
 }

--- a/spec/integration/ClientSpec.php
+++ b/spec/integration/ClientSpec.php
@@ -158,7 +158,7 @@ class ClientSpec extends ObjectBehavior
         $file_contents = file_get_contents( './spec/integration/basic_csv.csv' );
 
         $response = $this->sendEmail( getenv('FUNCTIONAL_TEST_EMAIL'), getenv('EMAIL_TEMPLATE_ID'), [
-            "name" => $this->prepareUpload( $file_contents, TRUE, TRUE, '4 weeks' )
+            "name" => $this->prepareUpload( $file_contents, 'report.csv', TRUE, '4 weeks' )
         ]);
 
         $response->shouldBeArray();

--- a/spec/unit/ClientSpec.php
+++ b/spec/unit/ClientSpec.php
@@ -721,17 +721,17 @@ class ClientSpec extends ObjectBehavior
 
 
     function it_generates_the_expected_request_when_preparing_file_for_upload(){
-        $this->prepareUpload('%PDF-1.5 testpdf')->shouldReturn( [ 'file' => 'JVBERi0xLjUgdGVzdHBkZg==', 'is_csv' => false, 'confirm_email_before_download' => NULL, 'retention_period' => NULL ] );
+        $this->prepareUpload('%PDF-1.5 testpdf')->shouldReturn( [ 'file' => 'JVBERi0xLjUgdGVzdHBkZg==', 'filename' => NULL, 'confirm_email_before_download' => NULL, 'retention_period' => NULL ] );
     }
 
 
     function it_generates_the_expected_request_when_preparing_a_csv_file_for_upload(){
-        $this->prepareUpload('%PDF-1.5 testpdf', true)->shouldReturn( [ 'file' => 'JVBERi0xLjUgdGVzdHBkZg==', 'is_csv' => true, 'confirm_email_before_download' => NULL, 'retention_period' => NULL ] );
+        $this->prepareUpload('%PDF-1.5 testpdf', 'report.csv')->shouldReturn( [ 'file' => 'JVBERi0xLjUgdGVzdHBkZg==', 'filename' => 'report.csv', 'confirm_email_before_download' => NULL, 'retention_period' => NULL ] );
     }
 
 
     function it_generates_the_expected_request_when_configuring_email_confirmation_and_retention(){
-        $this->prepareUpload('%PDF-1.5 testpdf', true, true, "1 weeks")->shouldReturn( [ 'file' => 'JVBERi0xLjUgdGVzdHBkZg==', 'is_csv' => true, 'confirm_email_before_download' => true, 'retention_period' => '1 weeks' ] );
+        $this->prepareUpload('%PDF-1.5 testpdf', null, true, "1 weeks")->shouldReturn( [ 'file' => 'JVBERi0xLjUgdGVzdHBkZg==', 'filename' => NULL, 'confirm_email_before_download' => true, 'retention_period' => '1 weeks' ] );
     }
 
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -25,7 +25,7 @@ class Client {
      * @const string Current version of this client.
      * This follows Semantic Versioning (http://semver.org/)
      */
-    const VERSION = '5.0.0';
+    const VERSION = '6.0.0';
 
     /**
      * @const string The API endpoint for Notify production.
@@ -392,21 +392,21 @@ class Client {
      * Prepare a file before adding it to the $personalisation array for the sendEmail function
      *
      * @param string $file_contents
-     * @param bool $is_csv
+     * @param string $filename
      * @param bool $confirm_email_before_download
      * @param string $retention_period
      *
      * @return array
      */
-    public function prepareUpload( $file_contents, $is_csv = false, $confirm_email_before_download = NULL, $retention_period = NULL ){
+    public function prepareUpload( $file_contents, $filename = NULL, $confirm_email_before_download = NULL, $retention_period = NULL ){
         if ( strlen($file_contents) > ( 2 * 1024 * 1024 )) {
             throw new Exception\InvalidArgumentException( 'File is larger than 2MB.' );
         }
         $data = [
             "file" => base64_encode($file_contents),
-            "is_csv" => $is_csv
         ];
 
+        $data['filename'] = $filename;
         $data['confirm_email_before_download'] = $confirm_email_before_download;
         $data['retention_period'] = $retention_period;
 


### PR DESCRIPTION
Update client for the new document download feature which allows specifying a download filename for files sent by email.

This supercedes the old isCsv parameter that was inconsistent at best.

Given this, we are dropping support for isCsv altogether.

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve updated the documentation (in `DOCUMENTATION.md` and `CHANGELOG.md`)
- [ ] I’ve bumped the version number (`const VERSION` in `src/Client.php`)
