### PR TITLE
Add support for setting an unsubscribe link when sending an email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [6.1.0] - 2024-5-10
 
-* Adds `unsubscribeLink` parameter to `sendEmail`
+* Adds `oneClickUnsubscribeURL` parameter to `sendEmail`
 
 ## [6.0.0] - 2023-12-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [6.1.0] - 2024-5-10
+
+* Adds `unsubscribeLink` parameter to `sendEmail`
+
 ## [6.0.0] - 2023-12-27
 
 * Removes the `is_csv` parameter from `prepareUpload`

--- a/spec/integration/ClientSpec.php
+++ b/spec/integration/ClientSpec.php
@@ -71,9 +71,9 @@ class ClientSpec extends ObjectBehavior
         $response['content']->shouldHaveKey( 'subject' );
         $response['content']['subject']->shouldBeString();
         $response['content']['subject']->shouldBe("Functional Tests are good");
-        $response['content']->shouldHaveKey( 'unsubscribe_link' );
-        $response['content']['unsubscribe_link']->shouldBeString();
-        $response['content']['unsubscribe_link']->shouldBe("https://www.example.com/unsubscribe");
+        $response['content']->shouldHaveKey( 'one_click_unsubscribe_url' );
+        $response['content']['one_click_unsubscribe_url']->shouldBeString();
+        $response['content']['one_click_unsubscribe_url']->shouldBe("https://www.example.com/unsubscribe");
 
         $response->shouldHaveKey( 'template' );
         $response['template']->shouldBeArray();
@@ -167,7 +167,7 @@ class ClientSpec extends ObjectBehavior
       $response->shouldHaveKey( 'reference' );
       $response->shouldHaveKey( 'email_address' );
       $response['email_address']->shouldBeString();
-      $response->shouldHaveKey( 'unsubscribe_link' );
+      $response->shouldHaveKey( 'one_click_unsubscribe_url' );
       $response->shouldHaveKey( 'phone_number' );
       $response->shouldHaveKey( 'line_1' );
       $response->shouldHaveKey( 'line_2' );

--- a/spec/integration/ClientSpec.php
+++ b/spec/integration/ClientSpec.php
@@ -49,6 +49,7 @@ class ClientSpec extends ObjectBehavior
           [ "name" => "Foo" ],
           'my_ref',
           getenv('EMAIL_REPLY_TO_ID'),
+          'https://www.example.com/unsubscribe'
         );
 
         $response->shouldBeArray();
@@ -70,6 +71,9 @@ class ClientSpec extends ObjectBehavior
         $response['content']->shouldHaveKey( 'subject' );
         $response['content']['subject']->shouldBeString();
         $response['content']['subject']->shouldBe("Functional Tests are good");
+        $response['content']->shouldHaveKey( 'unsubscribe_link' );
+        $response['content']['unsubscribe_link']->shouldBeString();
+        $response['content']['unsubscribe_link']->shouldBe("https://www.example.com/unsubscribe");
 
         $response->shouldHaveKey( 'template' );
         $response['template']->shouldBeArray();
@@ -163,6 +167,7 @@ class ClientSpec extends ObjectBehavior
       $response->shouldHaveKey( 'reference' );
       $response->shouldHaveKey( 'email_address' );
       $response['email_address']->shouldBeString();
+      $response->shouldHaveKey( 'unsubscribe_link' );
       $response->shouldHaveKey( 'phone_number' );
       $response->shouldHaveKey( 'line_1' );
       $response->shouldHaveKey( 'line_2' );

--- a/spec/integration/ClientSpec.php
+++ b/spec/integration/ClientSpec.php
@@ -43,50 +43,12 @@ class ClientSpec extends ObjectBehavior
 
     function it_receives_the_expected_response_when_sending_an_email_notification(){
 
-        $response = $this->sendEmail( getenv('FUNCTIONAL_TEST_EMAIL'), getenv('EMAIL_TEMPLATE_ID'), [
-            "name" => "Foo"
-        ]);
-
-        $response->shouldBeArray();
-        $response->shouldHaveKey( 'id' );
-        $response['id']->shouldBeString();
-
-        $response->shouldHaveKey( 'reference' );
-
-        $response->shouldHaveKey( 'content' );
-        $response['content']->shouldBeArray();
-        $response['content']->shouldHaveKey( 'from_email' );
-        $response['content']['from_email']->shouldBeString();
-        $response['content']->shouldHaveKey( 'body' );
-        $response['content']['body']->shouldBeString();
-        $response['content']['body']->shouldBe("Hello Foo\r\n\r\nFunctional test help make our world a better place");
-        $response['content']->shouldHaveKey( 'subject' );
-        $response['content']['subject']->shouldBeString();
-        $response['content']['subject']->shouldBe("Functional Tests are good");
-
-        $response->shouldHaveKey( 'template' );
-        $response['template']->shouldBeArray();
-        $response['template']->shouldHaveKey( 'id' );
-        $response['template']['id']->shouldBeString();
-        $response['template']->shouldHaveKey( 'version' );
-        $response['template']['version']->shouldBeInteger();
-        $response['template']->shouldHaveKey( 'uri' );
-
-        $response->shouldHaveKey( 'uri' );
-        $response['uri']->shouldBeString();
-
-        self::$notificationId = $response['id']->getWrappedObject();
-
-    }
-
-    function it_receives_the_expected_response_when_sending_an_email_notification_with_vaild_emailReplyToId(){
-
         $response = $this->sendEmail(
           getenv('FUNCTIONAL_TEST_EMAIL'),
           getenv('EMAIL_TEMPLATE_ID'),
           [ "name" => "Foo" ],
-          '',
-          getenv('EMAIL_REPLY_TO_ID')
+          'my_ref',
+          getenv('EMAIL_REPLY_TO_ID'),
         );
 
         $response->shouldBeArray();
@@ -94,6 +56,9 @@ class ClientSpec extends ObjectBehavior
         $response['id']->shouldBeString();
 
         $response->shouldHaveKey( 'reference' );
+        $response['reference']->shouldBeString();
+        $response['reference']->shouldBe("my_ref");
+
 
         $response->shouldHaveKey( 'content' );
         $response['content']->shouldBeArray();

--- a/spec/unit/ClientSpec.php
+++ b/spec/unit/ClientSpec.php
@@ -665,8 +665,56 @@ class ClientSpec extends ObjectBehavior
 
     }
 
-    function it_receives_the_expected_response_when_sending_email(){
+    function it_generates_the_expected_request_when_sending_email_with_unsubscribe_link(){
 
+        //---------------------------------
+        // Test Setup
+
+        $payload = [
+            'email_address' => 'text@example.com',
+            'template_id'=> 118,
+            'personalisation' => [
+                'name'=>'Fred'
+            ],
+            'reference'=>'client-ref',
+            'unsubscribe_link'=>'https://unsubscribelink.com/unsubscribe'
+        ];
+
+        $this->httpClient->sendRequest( Argument::type('Psr\Http\Message\RequestInterface') )->willReturn(
+            new Response(
+                201,
+                [ 'Content-type'  => 'application/json' ],
+                json_encode([ 'notification_id' => 'xxx' ])
+            )
+        );
+
+        //---------------------------------
+        // Perform action
+
+        $this->sendEmail( $payload['email_address'], $payload['template_id'], $payload['personalisation'], $payload['reference'], NULL, $payload['unsubscribe_link'] );
+
+        //---------------------------------
+        // Check result
+
+        $this->httpClient->sendRequest( Argument::that(function( $v ) use ($payload) {
+
+            // Check a request was sent.
+            if( !( $v instanceof RequestInterface ) ){
+                return false;
+            }
+
+            // With the expected body.
+            if( json_decode( $v->getBody(), true ) != $payload ){
+                return false;
+            }
+
+            return true;
+
+        }))->shouldHaveBeenCalled();
+
+    }
+
+    function it_receives_the_expected_response_when_sending_email(){
         //---------------------------------
         // Test Setup
 

--- a/spec/unit/ClientSpec.php
+++ b/spec/unit/ClientSpec.php
@@ -665,7 +665,7 @@ class ClientSpec extends ObjectBehavior
 
     }
 
-    function it_generates_the_expected_request_when_sending_email_with_unsubscribe_link(){
+    function it_generates_the_expected_request_when_sending_email_with_one_click_unsubscribe_url(){
 
         //---------------------------------
         // Test Setup
@@ -677,7 +677,7 @@ class ClientSpec extends ObjectBehavior
                 'name'=>'Fred'
             ],
             'reference'=>'client-ref',
-            'unsubscribe_link'=>'https://unsubscribelink.com/unsubscribe'
+            'one_click_unsubscribe_url'=>'https://oneClickUnsubscribeURL.com/unsubscribe'
         ];
 
         $this->httpClient->sendRequest( Argument::type('Psr\Http\Message\RequestInterface') )->willReturn(
@@ -691,7 +691,7 @@ class ClientSpec extends ObjectBehavior
         //---------------------------------
         // Perform action
 
-        $this->sendEmail( $payload['email_address'], $payload['template_id'], $payload['personalisation'], $payload['reference'], NULL, $payload['unsubscribe_link'] );
+        $this->sendEmail( $payload['email_address'], $payload['template_id'], $payload['personalisation'], $payload['reference'], NULL, $payload['one_click_unsubscribe_url'] );
 
         //---------------------------------
         // Check result

--- a/spec/unit/ClientSpec.php
+++ b/spec/unit/ClientSpec.php
@@ -694,30 +694,30 @@ class ClientSpec extends ObjectBehavior
 
     function it_receives_the_expected_response_when_sending_email_with_valid_emailReplyToId(){
 
-                //---------------------------------
-                // Test Setup
+        //---------------------------------
+        // Test Setup
 
-                $id = self::SAMPLE_ID;
+        $id = self::SAMPLE_ID;
 
-                $this->httpClient->sendRequest( Argument::type('Psr\Http\Message\RequestInterface') )->willReturn(
-                    new Response(
-                        201,
-                        ['Content-type'  => 'application/json'],
-                        json_encode(['notification_id' => $id])
-                    )
-                );
+        $this->httpClient->sendRequest( Argument::type('Psr\Http\Message\RequestInterface') )->willReturn(
+            new Response(
+                201,
+                ['Content-type'  => 'application/json'],
+                json_encode(['notification_id' => $id])
+            )
+        );
 
-                //---------------------------------
-                // Perform action
+        //---------------------------------
+        // Perform action
 
-                $response = $this->sendEmail( 'text@example.com', 118, [ 'name'=>'Fred' ], '',  uniqid() );
+        $response = $this->sendEmail( 'text@example.com', 118, [ 'name'=>'Fred' ], '',  uniqid() );
 
-                //---------------------------------
-                // Check result
+        //---------------------------------
+        // Check result
 
-                $response->shouldHaveKeyWithValue('notification_id', $id);
+        $response->shouldHaveKeyWithValue('notification_id', $id);
 
-            }
+    }
 
 
     function it_generates_the_expected_request_when_preparing_file_for_upload(){

--- a/src/Client.php
+++ b/src/Client.php
@@ -187,15 +187,15 @@ class Client {
      * @param string    $templateId
      * @param array     $personalisation
      * @param string    $reference
-     * @param string    $unsubscribeLink
+     * @param string    $oneClickUnsubscribeURL
      *
      * @return array
      */
-    public function sendEmail( $emailAddress, $templateId, array $personalisation = array(), $reference = '', $emailReplyToId = NULL, $unsubscribeLink = NULL ){
+    public function sendEmail( $emailAddress, $templateId, array $personalisation = array(), $reference = '', $emailReplyToId = NULL, $oneClickUnsubscribeURL = NULL ){
 
         return $this->httpPost(
             self::PATH_NOTIFICATION_SEND_EMAIL,
-            $this->buildEmailPayload( 'email', $emailAddress, $templateId, $personalisation, $reference, $emailReplyToId, $unsubscribeLink )
+            $this->buildEmailPayload( 'email', $emailAddress, $templateId, $personalisation, $reference, $emailReplyToId, $oneClickUnsubscribeURL )
         );
 
     }
@@ -465,11 +465,11 @@ class Client {
      * @param array     $personalisation
      * @param string    $reference
      * @param string    $emailReplyToId
-     * @param string    $unsubscribeLink
+     * @param string    $oneClickUnsubscribeURL
      *
      * @return array
      */
-    private function buildEmailPayload( $type, $to, $templateId, array $personalisation, $reference, $emailReplyToId = NULL, $unsubscribeLink = NULL ) {
+    private function buildEmailPayload( $type, $to, $templateId, array $personalisation, $reference, $emailReplyToId = NULL, $oneClickUnsubscribeURL = NULL ) {
 
         $payload = $this->buildPayload( $type, $to, $templateId, $personalisation, $reference );
 
@@ -477,8 +477,8 @@ class Client {
             $payload['email_reply_to_id'] = $emailReplyToId;
         }
 
-        if ( isset($unsubscribeLink) && $unsubscribeLink != '' ) {
-            $payload['unsubscribe_link'] = $unsubscribeLink;
+        if ( isset($oneClickUnsubscribeURL) && $oneClickUnsubscribeURL != '' ) {
+            $payload['one_click_unsubscribe_url'] = $oneClickUnsubscribeURL;
         }
 
         return $payload;

--- a/src/Client.php
+++ b/src/Client.php
@@ -25,7 +25,7 @@ class Client {
      * @const string Current version of this client.
      * This follows Semantic Versioning (http://semver.org/)
      */
-    const VERSION = '6.0.0';
+    const VERSION = '6.1.0';
 
     /**
      * @const string The API endpoint for Notify production.
@@ -187,14 +187,15 @@ class Client {
      * @param string    $templateId
      * @param array     $personalisation
      * @param string    $reference
+     * @param string    $unsubscribeLink
      *
      * @return array
      */
-    public function sendEmail( $emailAddress, $templateId, array $personalisation = array(), $reference = '', $emailReplyToId = NULL ){
+    public function sendEmail( $emailAddress, $templateId, array $personalisation = array(), $reference = '', $emailReplyToId = NULL, $unsubscribeLink = NULL ){
 
         return $this->httpPost(
             self::PATH_NOTIFICATION_SEND_EMAIL,
-            $this->buildEmailPayload( 'email', $emailAddress, $templateId, $personalisation, $reference, $emailReplyToId )
+            $this->buildEmailPayload( 'email', $emailAddress, $templateId, $personalisation, $reference, $emailReplyToId, $unsubscribeLink )
         );
 
     }
@@ -464,15 +465,20 @@ class Client {
      * @param array     $personalisation
      * @param string    $reference
      * @param string    $emailReplyToId
+     * @param string    $unsubscribeLink
      *
      * @return array
      */
-    private function buildEmailPayload( $type, $to, $templateId, array $personalisation, $reference, $emailReplyToId = NULL ) {
+    private function buildEmailPayload( $type, $to, $templateId, array $personalisation, $reference, $emailReplyToId = NULL, $unsubscribeLink = NULL ) {
 
         $payload = $this->buildPayload( $type, $to, $templateId, $personalisation, $reference );
 
         if ( isset($emailReplyToId) && $emailReplyToId != '' ) {
             $payload['email_reply_to_id'] = $emailReplyToId;
+        }
+
+        if ( isset($unsubscribeLink) && $unsubscribeLink != '' ) {
+            $payload['unsubscribe_link'] = $unsubscribeLink;
         }
 
         return $payload;


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
Should be the equivalent of
https://github.com/alphagov/notifications-python-client/pull/241

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve updated the documentation in
  - [x] [notifications-tech-docs repository](https://github.com/alphagov/notifications-tech-docs/blob/main/source/documentation/client_docs/_php.md)
  - [x] `CHANGELOG.md`
- [x] I’ve bumped the version number (`const VERSION` in `src/Client.php`)
