### PR TITLE
chore: include new notification fields (cost_in_pounds, is_data_ready and cost_details)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [6.2.0] - 2024-07-29
+
+### Added
+
+* Added fields related to cost data in response:
+  * `is_cost_data_ready`: This field is true if cost data is ready, and false if it isn't (Boolean).
+  * `cost_in_pounds`: Cost of the notification in pounds. The cost does not take free allowance into account (Float).
+  * `cost_details.billable_sms_fragments`: Number of billable SMS fragments in your text message (SMS only) (Integer).
+  * `cost_details.international_rate_multiplier`: For international SMS rate is multiplied by this value (SMS only) (Integer).
+  * `cost_details.sms_rate`: Cost of 1 SMS fragment (SMS only) (Float).
+  * `cost_details.billable_sheets_of_paper`: Number of sheets of paper in the letter you sent, that you will be charged for (letter only) (Integer).
+  * `cost_details.postage`: Postage class of the notification sent (letter only) (String).
+
 ## [6.1.0] - 2024-5-10
 
 * Adds `oneClickUnsubscribeURL` parameter to `sendEmail`

--- a/spec/integration/ClientSpec.php
+++ b/spec/integration/ClientSpec.php
@@ -195,6 +195,16 @@ class ClientSpec extends ObjectBehavior
       $response->shouldHaveKey( 'sent_at' );
       $response->shouldHaveKey( 'completed_at' );
 
+      $response->shouldHaveKey('cost_details');
+      $response['cost_details']->shouldBeArray();
+
+       $response->shouldHaveKey('cost_in_pounds');
+       $response['cost_in_pounds']->shouldBe(0.0);
+
+       $response->shouldHaveKey('is_cost_data_ready');
+       $response['is_cost_data_ready']->shouldBe(true);
+
+
       self::$notificationId = $response['id']->getWrappedObject();
 
     }
@@ -284,6 +294,14 @@ class ClientSpec extends ObjectBehavior
       $response->shouldHaveKey( 'sent_at' );
       $response->shouldHaveKey( 'completed_at' );
 
+      $response->shouldHaveKey('cost_details');
+      $response['cost_details']->shouldBeArray();
+      $response->shouldHaveKey('cost_in_pounds');
+      $response->shouldHaveKey('is_cost_data_ready');
+
+      $response['cost_details']->shouldHaveKey( 'billable_sms_fragments' );
+      $response['cost_details']->shouldHaveKey( 'international_rate_multiplier' );
+      $response['cost_details']->shouldHaveKey( 'sms_rate' );
     }
 
     function it_receives_the_expected_response_when_looking_up_all_notifications() {

--- a/spec/integration/ClientSpec.php
+++ b/spec/integration/ClientSpec.php
@@ -779,4 +779,63 @@ class ClientSpec extends ObjectBehavior
       $resp->shouldBeString();
       $resp->shouldStartWith( "%PDF-" );
     }
+
+function it_receives_the_expected_response_when_looking_up_a_letter_notification() {
+      // Requires the 'it_receives_the_expected_response_when_sending_a_letter_notification' test to have completed successfully
+      if(is_null(self::$letterNotificationId)) {
+          throw new UnexpectedValueException('Letter ID not set');
+      }
+
+      $notificationId = self::$letterNotificationId;
+
+      // Retrieve letter notification by id and verify contents
+      $response = $this->getNotification($notificationId);
+      $response->shouldBeArray();
+      $response->shouldHaveKey( 'id' );
+      $response['id']->shouldBeString();
+
+      $response->shouldHaveKey( 'body' );
+      $response['body']->shouldBe('Hello Foo');
+      $response->shouldHaveKey( 'subject' );
+
+      $response->shouldHaveKey( 'reference' );
+      $response->shouldHaveKey( 'email_address' );
+      $response->shouldHaveKey( 'phone_number' );
+      $response->shouldHaveKey( 'line_1' );
+      $response->shouldHaveKey( 'line_2' );
+      $response->shouldHaveKey( 'line_3' );
+      $response->shouldHaveKey( 'line_4' );
+      $response->shouldHaveKey( 'line_5' );
+      $response->shouldHaveKey( 'line_6' );
+      $response['line_1']->shouldBeString();
+      $response['line_2']->shouldBeString();
+
+      $response->shouldHaveKey( 'postcode' );
+      $response->shouldHaveKey( 'type' );
+      $response['type']->shouldBeString();
+      $response['type']->shouldBe('letter');
+      $response->shouldHaveKey( 'status' );
+      $response['status']->shouldBeString();
+
+      $response->shouldHaveKey( 'template' );
+      $response['template']->shouldBeArray();
+      $response['template']->shouldHaveKey( 'id' );
+      $response['template']['id']->shouldBeString();
+      $response['template']->shouldHaveKey( 'version' );
+      $response['template']['version']->shouldBeInteger();
+      $response['template']->shouldHaveKey( 'uri' );
+      $response['template']['uri']->shouldBeString();
+
+      $response->shouldHaveKey( 'created_at' );
+      $response->shouldHaveKey( 'sent_at' );
+      $response->shouldHaveKey( 'completed_at' );
+
+      $response->shouldHaveKey('cost_details');
+      $response['cost_details']->shouldBeArray();
+      $response->shouldHaveKey('cost_in_pounds');
+      $response->shouldHaveKey('is_cost_data_ready');
+
+      $response['cost_details']->shouldHaveKey( 'billable_sheets_of_paper' );
+      $response['cost_details']->shouldHaveKey( 'postage' );
+    }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -25,7 +25,7 @@ class Client {
      * @const string Current version of this client.
      * This follows Semantic Versioning (http://semver.org/)
      */
-    const VERSION = '6.1.0';
+    const VERSION = '6.2.0';
 
     /**
      * @const string The API endpoint for Notify production.


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
New fields have been added to the response of `get_notification(notificationId)` endpoint
- cost_in_pounds
- is_cost_data_ready
- cost_details:
-- **Nested fields for letters**:
--- billable_sheets_of_paper
--- postage
-- **Nested fields for sms**:
--- billable_sms_fragments
--- international_rate_multiplier
--- sms_rate
 
Based on the addition this PR updates our client documentation to showcase an aligned response for the endpoint

### Related task : 
[3. Add GET notification cost data to API clients and API client docs](https://trello.com/c/5VZrBNpU/845-3-add-get-notification-cost-data-to-api-clients-and-api-client-docs)

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve updated the documentation in
  - [x] [notifications-tech-docs repository](https://github.com/alphagov/notifications-tech-docs/blob/main/source/documentation/client_docs/_php.md)
  - [x] `CHANGELOG.md`
- [x] I’ve bumped the version number (`const VERSION` in `src/Client.php`)
