### PR TITLE
Dockerfile: Install awscli & copy repo into workdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,17 @@ RUN \
     echo "Install base packages" \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
+    awscli \
     git \
     gnupg \
+    jq \
     zip \
     unzip
 
 RUN curl --silent --show-error https://getcomposer.org/installer | php -- --install-dir /usr/local/bin --filename composer
 
 WORKDIR /var/project
+COPY . .
 
 ENV COMPOSER_ALLOW_SUPERUSER=1
 ENV COMPOSER_NO_INTERACTION=1


### PR DESCRIPTION
In the new deploy pipeline, the AWS cli will be used to fetch the SSM parameter containing the environment variables required to run the integration tests.

We also copy the repo into the built image so that we don't need to _also_ back the repo into the deployment bag.