### PR TITLE
ClientSpec: Remove an incorrect assertion

### DIFF
--- a/spec/integration/ClientSpec.php
+++ b/spec/integration/ClientSpec.php
@@ -555,8 +555,6 @@ class ClientSpec extends ObjectBehavior
 
           } elseif ( $template_type == "letter") {
             $template['subject']->shouldBeString();
-            $template['letter_contact_block']->shouldBeString();
-
           }
       }
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/D1m5uleD/952-run-api-client-integration-tests-as-part-of-new-pipeline)

It's valid for letters to have no contact block, so the behaviour here should really be to check if it's a string _or null_. As far as I can tell PHPSpec doesn't provide such a matcher, and I don't want to make one, so let's just remove this assertion.