### PR TITLE
integration tests: don't assert exact `created_by` for template version

### DIFF
--- a/spec/integration/ClientSpec.php
+++ b/spec/integration/ClientSpec.php
@@ -501,7 +501,6 @@ class ClientSpec extends ObjectBehavior
       $response['name']->shouldBe( 'Example text message template' );
       $response['created_at']->shouldBeString();
       $response['created_by']->shouldBeString();
-      $response['created_by']->shouldMatch( '/^notify-tests-preview.+@digital\.cabinet-office\.gov\.uk$/' );
       $response['version']->shouldBeInteger();
       $response['version']->shouldBe( $version );
       $response['body']->shouldBe("Hey ((name)), I’m trying out Notify. Today is ((day of week)) and my favourite colour is ((colour)).");


### PR DESCRIPTION
This check isn't strictly necessary and makes creating db fixtures that little bit more painful.